### PR TITLE
setting default of new expression to be vectorized

### DIFF
--- a/R/new-expr.R
+++ b/R/new-expr.R
@@ -79,7 +79,7 @@ new_expr.mb_meta_analyses <- function(object, ...) {
 #' @param new_expr Must be passed as `{{ new_expr }}` by the caller.
 #' @param default A quoted expression to use as fallback.
 #' @param vectorize Set to `TRUE` to call `mcmcderive::expression_vectorize()` on the result.
-#'   The current default is to not vectorize, this can change later.
+#'   The current default is to vectorize. Change to FALSE to turn off.
 #' @return `new_expr` quoted and (if needed) parsed, or `default` if `new_expr` is `NULL`.
 #' @noRd
 enexpr_new_expr <- function(new_expr, default = NULL, vectorize = TRUE) {

--- a/R/new-expr.R
+++ b/R/new-expr.R
@@ -82,7 +82,7 @@ new_expr.mb_meta_analyses <- function(object, ...) {
 #'   The current default is to not vectorize, this can change later.
 #' @return `new_expr` quoted and (if needed) parsed, or `default` if `new_expr` is `NULL`.
 #' @noRd
-enexpr_new_expr <- function(new_expr, default = NULL, vectorize = NULL) {
+enexpr_new_expr <- function(new_expr, default = NULL, vectorize = TRUE) {
   new_expr <- enquo(new_expr)
   if (quo_is_null(new_expr)) {
     new_expr <- default


### PR DESCRIPTION
Updating default to vectorize the new expression. 
Tests and checks pass. 

Tested on actual analysis as well and changed run times of predict from 0.739 secs to 0.160 and caused no errors when running analyse, predict, residual or sensitivity script. 