### PR TITLE
Set the default behaviour to vectorize the new expression

### DIFF
--- a/R/derive-data.R
+++ b/R/derive-data.R
@@ -24,7 +24,11 @@ mcmc_derive_fun <- function(object,
 
   model <- model(object)
 
-  new_expr <- enexpr_new_expr({{ new_expr }}, default = model$new_expr)
+  new_expr <- enexpr_new_expr(
+    {{ new_expr }},
+    default = model$new_expr,
+    vectorize = FALSE
+  )
 
   data <- embr::modify_new_data(
     new_data,

--- a/R/new-expr.R
+++ b/R/new-expr.R
@@ -102,6 +102,10 @@ enexpr_new_expr <- function(new_expr, default = NULL, vectorize = NULL) {
   }
 
   # If we later want to change the default, change this code only.
+  if (is.null(vectorize)) {
+    vectorize <- TRUE
+  }
+
   if (!is.null(new_expr) && isTRUE(vectorize)) {
     new_expr <- mcmcderive::expression_vectorize(new_expr)
   }

--- a/R/new-expr.R
+++ b/R/new-expr.R
@@ -78,8 +78,8 @@ new_expr.mb_meta_analyses <- function(object, ...) {
 #'
 #' @param new_expr Must be passed as `{{ new_expr }}` by the caller.
 #' @param default A quoted expression to use as fallback.
-#' @param vectorize Set to `TRUE` to call `mcmcderive::expression_vectorize()` on the result.
-#'   The current default is to not vectorize, this can change later.
+#' @param vectorize The current default is to vectorize. Set to `FALSE` to not
+#'  vectorize.
 #' @return `new_expr` quoted and (if needed) parsed, or `default` if `new_expr` is `NULL`.
 #' @noRd
 enexpr_new_expr <- function(new_expr, default = NULL, vectorize = NULL) {


### PR DESCRIPTION
The default is now set in the model description that it will vectorize the new expression. To not vectorize the new expression the user must set `new_expr_vec = FALSE` in the model definition. 

This was tested in a real analysis and appears to function as expected. 
Tests and checks run and passing. 