### PR TITLE
Add the `new_expr_vec` parameter to `update_model()` 

### DIFF
--- a/R/derive-data.R
+++ b/R/derive-data.R
@@ -24,7 +24,11 @@ mcmc_derive_fun <- function(object,
 
   model <- model(object)
 
-  new_expr <- enexpr_new_expr({{ new_expr }}, default = model$new_expr)
+  new_expr <- enexpr_new_expr(
+    {{ new_expr }},
+    default = model$new_expr,
+    vectorize = FALSE
+  )
 
   data <- embr::modify_new_data(
     new_data,

--- a/R/new-expr.R
+++ b/R/new-expr.R
@@ -102,6 +102,10 @@ enexpr_new_expr <- function(new_expr, default = NULL, vectorize = NULL) {
   }
 
   # If we later want to change the default, change this code only.
+  if (is.null(vectorize)) {
+    vectorize <- TRUE
+  }
+
   if (!is.null(new_expr) && isTRUE(vectorize)) {
     new_expr <- mcmcderive::expression_vectorize(new_expr)
   }

--- a/R/new-expr.R
+++ b/R/new-expr.R
@@ -78,8 +78,8 @@ new_expr.mb_meta_analyses <- function(object, ...) {
 #'
 #' @param new_expr Must be passed as `{{ new_expr }}` by the caller.
 #' @param default A quoted expression to use as fallback.
-#' @param vectorize Set to `TRUE` to call `mcmcderive::expression_vectorize()` on the result.
-#'   The current default is to not vectorize, this can change later.
+#' @param vectorize The current default is to vectorize. Set to `FALSE` to not
+#'  vectorize.
 #' @return `new_expr` quoted and (if needed) parsed, or `default` if `new_expr` is `NULL`.
 #' @noRd
 enexpr_new_expr <- function(new_expr, default = NULL, vectorize = NULL) {

--- a/R/update-model.R
+++ b/R/update-model.R
@@ -7,20 +7,44 @@
 #' @inheritParams model.mb_code
 #' @return An object inheriting from class mb_model.
 #' @export
-update_model <- function(model, code = NULL, gen_inits = NULL,
-                         random_effects = NULL, fixed = NULL, derived = NULL, select_data = NULL,
-                         center = NULL, scale = NULL, modify_data = NULL,
-                         nthin = NULL, new_expr = NULL, new_expr_vec = NULL, modify_new_data = NULL,
-                         drops = NULL, ...) {
+update_model <- function(
+    model,
+    code = NULL,
+    gen_inits = NULL,
+    random_effects = NULL,
+    fixed = NULL,
+    derived = NULL,
+    select_data = NULL,
+    center = NULL,
+    scale = NULL,
+    modify_data = NULL,
+    nthin = NULL,
+    new_expr = NULL,
+    new_expr_vec = NULL,
+    modify_new_data = NULL,
+    drops = NULL,
+    ...) {
   UseMethod("update_model")
 }
 
 #' @export
-update_model.mb_model <- function(model, code = NULL, gen_inits = NULL,
-                                  random_effects = NULL, fixed = NULL, derived = NULL, select_data = NULL,
-                                  center = NULL, scale = NULL, modify_data = NULL,
-                                  nthin = NULL, new_expr = NULL, new_expr_vec = NULL, modify_new_data = NULL,
-                                  drops = NULL, ...) {
+update_model.mb_model <- function(
+    model,
+    code = NULL,
+    gen_inits = NULL,
+    random_effects = NULL,
+    fixed = NULL,
+    derived = NULL,
+    select_data = NULL,
+    center = NULL,
+    scale = NULL,
+    modify_data = NULL,
+    nthin = NULL,
+    new_expr = NULL,
+    new_expr_vec = NULL,
+    modify_new_data = NULL,
+    drops = NULL,
+    ...) {
 
   if (is.null(code)) code <- code(model)
   if (is.null(gen_inits)) gen_inits <- model$gen_inits

--- a/R/update-model.R
+++ b/R/update-model.R
@@ -10,7 +10,7 @@
 update_model <- function(model, code = NULL, gen_inits = NULL,
                          random_effects = NULL, fixed = NULL, derived = NULL, select_data = NULL,
                          center = NULL, scale = NULL, modify_data = NULL,
-                         nthin = NULL, new_expr = NULL, modify_new_data = NULL,
+                         nthin = NULL, new_expr = NULL, new_expr_vec = NULL, modify_new_data = NULL,
                          drops = NULL, ...) {
   UseMethod("update_model")
 }
@@ -19,10 +19,8 @@ update_model <- function(model, code = NULL, gen_inits = NULL,
 update_model.mb_model <- function(model, code = NULL, gen_inits = NULL,
                                   random_effects = NULL, fixed = NULL, derived = NULL, select_data = NULL,
                                   center = NULL, scale = NULL, modify_data = NULL,
-                                  nthin = NULL, new_expr = NULL, modify_new_data = NULL,
+                                  nthin = NULL, new_expr = NULL, new_expr_vec = NULL, modify_new_data = NULL,
                                   drops = NULL, ...) {
-
-
 
   if (is.null(code)) code <- code(model)
   if (is.null(gen_inits)) gen_inits <- model$gen_inits
@@ -34,7 +32,7 @@ update_model.mb_model <- function(model, code = NULL, gen_inits = NULL,
   if (is.null(scale)) scale <- model$scale
   if (is.null(modify_data)) modify_data <- model$modify_data
   if (is.null(nthin)) nthin <- model$nthin
-  new_expr <- enexpr_new_expr({{ new_expr }}, default = model$new_expr)
+  new_expr <- enexpr_new_expr({{ new_expr }}, default = model$new_expr, vectorize = new_expr_vec)
   if (is.null(modify_new_data)) modify_new_data <- model$modify_new_data
   if (is.null(drops)) drops <- model$drops
 
@@ -50,6 +48,7 @@ update_model.mb_model <- function(model, code = NULL, gen_inits = NULL,
     modify_data = modify_data,
     nthin = nthin,
     new_expr = !!new_expr,
+    new_expr_vec =  new_expr_vec,
     modify_new_data = modify_new_data,
     drops = drops
   ))

--- a/man/update_model.Rd
+++ b/man/update_model.Rd
@@ -17,6 +17,7 @@ update_model(
   modify_data = NULL,
   nthin = NULL,
   new_expr = NULL,
+  new_expr_vec = NULL,
   modify_new_data = NULL,
   drops = NULL,
   ...
@@ -47,6 +48,8 @@ returning a named list of initial values.}
 \item{nthin}{A count specifying the thinning interval.}
 
 \item{new_expr}{A string of R code specifying the predictive relationships.}
+
+\item{new_expr_vec}{A flag specifying whether to vectorize the new_expr code.}
 
 \item{modify_new_data}{A single argument function to modify new data (in list form) immediately prior to calculating new_expr.}
 

--- a/tests/testthat/_snaps/new-expr-update.md
+++ b/tests/testthat/_snaps/new-expr-update.md
@@ -22,3 +22,15 @@
           residual <- res_lnorm(Density, fit, exp(log_sDensity))
       }
 
+# add new_expr_vec argument to update model
+
+    Code
+      new_expr(analysis)
+    Output
+      for (i in 1:length(Density)) {
+          fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + 
+              bSiteYear[Site[i], YearFactor[i]]
+          log(prediction[i]) <- fit[i]
+          residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
+      }
+

--- a/tests/testthat/_snaps/new-expr-update.md
+++ b/tests/testthat/_snaps/new-expr-update.md
@@ -46,3 +46,15 @@
           residual <- res_lnorm(Density, fit, exp(log_sDensity))
       }
 
+# cannot undo the vectorization if orignally set in the model
+
+    Code
+      new_expr(analysis)
+    Output
+      {
+          fit <- bIntercept + bYear * Year + bHabitatQuality[HabitatQuality] + 
+              bSiteYear[cbind(Site, YearFactor)]
+          log(prediction) <- fit
+          residual <- res_lnorm(Density, fit, exp(log_sDensity))
+      }
+

--- a/tests/testthat/_snaps/new-expr-update.md
+++ b/tests/testthat/_snaps/new-expr-update.md
@@ -34,3 +34,15 @@
           residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
       }
 
+# add new_expr_vec argument to update model and updates original new_expr
+
+    Code
+      new_expr(analysis)
+    Output
+      {
+          fit <- bIntercept + bYear * Year + bHabitatQuality[HabitatQuality] + 
+              bSiteYear[cbind(Site, YearFactor)]
+          log(prediction) <- fit
+          residual <- res_lnorm(Density, fit, exp(log_sDensity))
+      }
+

--- a/tests/testthat/test-new-expr-update.R
+++ b/tests/testthat/test-new-expr-update.R
@@ -283,3 +283,71 @@ test_that("add new_expr_vec argument to update model and updates original new_ex
   local_edition(3)
   expect_snapshot(new_expr(analysis))
 })
+
+test_that("cannot undo the vectorization if orignally set in the model", {
+  skip_if_not_installed("jmbr")
+
+  set_analysis_mode("quick")
+
+  data <- embr::density99
+  data$YearFactor <- factor(data$Year)
+
+  model <- model("model{
+
+  bIntercept ~ dnorm(0, 5^-2)
+  bYear ~ dnorm(0, .5^-2) # bYear2 ~ dnorm(0, .5^-2)
+
+  bHabitatQuality[1] <- 0
+  for(i in 2:nHabitatQuality) {
+    bHabitatQuality[i] ~ dnorm(0, 5.^-2) T(0,)
+  }
+
+  log_sSiteYear ~ dlnorm(0, 5^-2)
+  log_sDensity ~ dt(0, 5^-2, 4.5)
+
+  log(sSiteYear) <- log_sSiteYear
+  log(sDensity) <- log_sDensity
+
+  for(i in 1:nSite) {
+    for(j in 1:nYearFactor) {
+      bSiteYear[i,j] ~ dnorm(0, sSiteYear^-2)
+    }
+  }
+
+  for(i in 1:length(Density)) {
+    eDensity[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+    Density[i] ~ dlnorm(eDensity[i], sDensity^-2)
+  }
+  }",
+  new_expr = "
+  for(i in 1:length(Density)) {
+    fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+    log(prediction[i]) <- fit[i]
+    residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
+  }",
+  new_expr_vec = TRUE,
+  select_data = list("Year+" = numeric(), YearFactor = factor(),
+                     Site = factor(), Density = numeric(),
+                     HabitatQuality = factor()),
+  fixed = "^(b|l)", derived = "eDensity",
+  random_effects = list(bSiteYear = c("Site", "YearFactor")))
+
+  model <- update_model(
+    model,
+    new_expr_vec = FALSE
+  )
+  expect_output(expect_warning(analysis <- analyse(model, data = data)))
+
+  year <- predict(analysis, new_data = "Year")
+
+  expect_is(year, "tbl")
+  expect_identical(colnames(year), c("Site", "HabitatQuality", "Year", "Visit",
+                                     "Density", "YearFactor",
+                                     "estimate", "lower", "upper", "svalue"))
+  expect_true(all(year$lower < year$estimate))
+  expect_false(is.unsorted(year$estimate))
+
+  local_edition(3)
+  expect_snapshot(new_expr(analysis))
+})
+

--- a/tests/testthat/test-new-expr-update.R
+++ b/tests/testthat/test-new-expr-update.R
@@ -142,3 +142,79 @@ random_effects = list(bSiteYear = c("Site", "YearFactor")))
   local_edition(3)
   expect_snapshot(new_expr(analysis))
 })
+
+test_that("add new_expr_vec argument to update model", {
+  skip_if_not_installed("jmbr")
+
+  set_analysis_mode("quick")
+
+  data <- embr::density99
+  data$YearFactor <- factor(data$Year)
+
+  model <- model("model{
+
+  bIntercept ~ dnorm(0, 5^-2)
+  bYear ~ dnorm(0, .5^-2) # bYear2 ~ dnorm(0, .5^-2)
+
+  bHabitatQuality[1] <- 0
+  for(i in 2:nHabitatQuality) {
+    bHabitatQuality[i] ~ dnorm(0, 5.^-2) T(0,)
+  }
+
+  log_sSiteYear ~ dlnorm(0, 5^-2)
+  log_sDensity ~ dt(0, 5^-2, 4.5)
+
+  log(sSiteYear) <- log_sSiteYear
+  log(sDensity) <- log_sDensity
+
+  for(i in 1:nSite) {
+    for(j in 1:nYearFactor) {
+      bSiteYear[i,j] ~ dnorm(0, sSiteYear^-2)
+    }
+  }
+
+  for(i in 1:length(Density)) {
+    eDensity[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+    Density[i] ~ dlnorm(eDensity[i], sDensity^-2)
+  }
+  }",
+  new_expr = "
+  for(i in 1:length(Density)) {
+    fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+    log(prediction[i]) <- fit[i]
+    residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
+  }",
+  new_expr_vec = TRUE,
+  select_data = list("Year+" = numeric(), YearFactor = factor(),
+                   Site = factor(), Density = numeric(),
+                   HabitatQuality = factor()),
+  fixed = "^(b|l)", derived = "eDensity",
+  random_effects = list(bSiteYear = c("Site", "YearFactor")))
+
+  model <- update_model(
+    model,
+    new_expr =
+      "
+      for(i in 1:length(Density)) {
+        fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+        log(prediction[i]) <- fit[i]
+        residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
+      }",
+    new_expr_vec = FALSE
+    )
+  expect_output(expect_warning(analysis <- analyse(model, data = data)))
+
+  year <- predict(analysis, new_data = "Year")
+
+  expect_is(year, "tbl")
+  expect_identical(colnames(year), c("Site", "HabitatQuality", "Year", "Visit",
+                                     "Density", "YearFactor",
+                                     "estimate", "lower", "upper", "svalue"))
+  expect_true(all(year$lower < year$estimate))
+  expect_false(is.unsorted(year$estimate))
+
+  local_edition(3)
+  expect_snapshot(new_expr(analysis))
+})
+
+

--- a/tests/testthat/test-new-expr-update.R
+++ b/tests/testthat/test-new-expr-update.R
@@ -217,4 +217,69 @@ test_that("add new_expr_vec argument to update model", {
   expect_snapshot(new_expr(analysis))
 })
 
+test_that("add new_expr_vec argument to update model and updates original new_expr", {
+  skip_if_not_installed("jmbr")
 
+  set_analysis_mode("quick")
+
+  data <- embr::density99
+  data$YearFactor <- factor(data$Year)
+
+  model <- model("model{
+
+  bIntercept ~ dnorm(0, 5^-2)
+  bYear ~ dnorm(0, .5^-2) # bYear2 ~ dnorm(0, .5^-2)
+
+  bHabitatQuality[1] <- 0
+  for(i in 2:nHabitatQuality) {
+    bHabitatQuality[i] ~ dnorm(0, 5.^-2) T(0,)
+  }
+
+  log_sSiteYear ~ dlnorm(0, 5^-2)
+  log_sDensity ~ dt(0, 5^-2, 4.5)
+
+  log(sSiteYear) <- log_sSiteYear
+  log(sDensity) <- log_sDensity
+
+  for(i in 1:nSite) {
+    for(j in 1:nYearFactor) {
+      bSiteYear[i,j] ~ dnorm(0, sSiteYear^-2)
+    }
+  }
+
+  for(i in 1:length(Density)) {
+    eDensity[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+    Density[i] ~ dlnorm(eDensity[i], sDensity^-2)
+  }
+  }",
+  new_expr = "
+  for(i in 1:length(Density)) {
+    fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
+    log(prediction[i]) <- fit[i]
+    residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
+  }",
+  new_expr_vec = FALSE,
+  select_data = list("Year+" = numeric(), YearFactor = factor(),
+                     Site = factor(), Density = numeric(),
+                     HabitatQuality = factor()),
+  fixed = "^(b|l)", derived = "eDensity",
+  random_effects = list(bSiteYear = c("Site", "YearFactor")))
+
+  model <- update_model(
+    model,
+    new_expr_vec = TRUE
+  )
+  expect_output(expect_warning(analysis <- analyse(model, data = data)))
+
+  year <- predict(analysis, new_data = "Year")
+
+  expect_is(year, "tbl")
+  expect_identical(colnames(year), c("Site", "HabitatQuality", "Year", "Visit",
+                                     "Density", "YearFactor",
+                                     "estimate", "lower", "upper", "svalue"))
+  expect_true(all(year$lower < year$estimate))
+  expect_false(is.unsorted(year$estimate))
+
+  local_edition(3)
+  expect_snapshot(new_expr(analysis))
+})


### PR DESCRIPTION
The parameter has been added and tests to confirm the behaviour works. 

One point to note is that you can do this which will vectorize the current `new_expr` if it was originally set to  `new_expr_vec = FALSE`

```
model <- update_model(
    model,
    new_expr_vec = TRUE
  )
```

but the reverse would not occur when updating the model to set `new_expr_vec = FALSE` ie it can not un-vectorize the new_expression if was initially set to be vectorized in the model definition. 