### PR TITLE
Only apply as.numeric() after selecting the relevant columns

### DIFF
--- a/R/zero.R
+++ b/R/zero.R
@@ -2,8 +2,8 @@ zero_random_effects <- function(mcmcr, data, random_effects) {
   stopifnot(all(names(random_effects) %in% pars(mcmcr)))
   stopifnot(all(unlist(random_effects) %in% names(data)))
 
-  data <- llply(data, as.numeric)
   data <- data[unique(unlist(random_effects))]
+  data <- lapply(data, as.numeric)
   data <- data[vapply(data, all1, TRUE)]
   data <- names(data)
 


### PR DESCRIPTION
This fixes warnings in the default analysis.