### PR TITLE
- Remove logLik and IC columns from glance output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,6 +65,6 @@ Remotes:
     poissonconsulting/rescale
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.2.9000
 Config/testthat/edition: 3
 Config/Needs/website: poissonconsulting/poissontemplate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: embr
 Title: Model Builder Utility Functions and Virtual Classes
-Version: 0.0.1.9037
+Version: 0.0.1.9038
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
+# embr 0.0.1.9038
+
+- Remove `logLik` and `IC` columns from glance output.
+
 # embr 0.0.1.9037
 
 ## Features

--- a/R/glance.R
+++ b/R/glance.R
@@ -8,11 +8,6 @@ glance.mb_analysis <- function(x, rhat = getOption("mb.rhat", 1.1), esr = getOpt
     K = nterms(x, include_constant = FALSE)
   )
 
-  if (is_frequentist(x) || is_new_parameter(x, "log_lik")) {
-    glance$logLik <- logLik(x)
-    glance$IC <- round(IC(x), 2)
-  }
-
   if (is_bayesian(x)) {
     glance$nchains <- nchains(x)
     glance$niters <- niters(x)
@@ -57,12 +52,5 @@ glance.mb_analyses <- function(
     return(as_tibble(glance))
   }
   x <- purrr::map_dfr(x, glance, .id = "model")
-  if ("IC" %in% colnames(x)) {
-    x$deltaIC <- x$IC - min(x$IC)
-    colnames <- colnames(x)
-    n <- length(colnames)
-    colnames <- colnames[c(1:5, n, 6:(n - 1))]
-    x <- x[colnames]
-  }
   x
 }

--- a/tests/testthat/test-mb-null-analysis.R
+++ b/tests/testthat/test-mb-null-analysis.R
@@ -9,7 +9,7 @@ test_that("mb_null_analysis", {
 
   glance <- glance(analysis)
   expect_s3_class(glance, "tbl")
-  expect_identical(colnames(glance), c("n", "K", "logLik", "IC", "converged"))
+  expect_identical(colnames(glance), c("n", "K", "converged"))
   expect_identical(nrow(glance), 1L)
 
   tidy <- tidy(analysis)


### PR DESCRIPTION
Closes #34

The logLik component was causing me issues when writing tests for my new sensitivity functions.
I saw this was already filed as an issue so decided to make the change.