### PR TITLE
add smb2_model/smb2_code class for use by smbr2 and cmdstanr

### DIFF
--- a/R/mb-code.R
+++ b/R/mb-code.R
@@ -5,7 +5,7 @@
 #' @param template A string, a braced `{}` expression (unquoted or quoted),
 #'   or an object of class `"mb_code"`.
 #' @param stan_engine A string indicating the Stan engine to use, e.g., `"cmdstanr"`.
-#' Currently, any value other than `"cmdstanr"` will assume the engine is `"rstan"`.
+#' Currently, any value other than `"cmdstanr"` will default to `"rstan"`.
 #'
 #' @return An object inheriting from class mb_code.
 #' @export

--- a/R/mb-code.R
+++ b/R/mb-code.R
@@ -4,6 +4,8 @@
 #'
 #' @param template A string, a braced `{}` expression (unquoted or quoted),
 #'   or an object of class `"mb_code"`.
+#' @param stan_engine A string indicating the Stan engine to use, e.g., `"cmdstanr"`.
+#' Currently, any value other than `"cmdstanr"` will assume the engine is `"rstan"`.
 #'
 #' @return An object inheriting from class mb_code.
 #' @export
@@ -28,7 +30,7 @@
 #' "
 #' )
 #' class(x)
-mb_code <- function(template) {
+mb_code <- function(template, stan_engine = character(0)) {
   template_expr <- quo_get_expr(enquo(template))
 
   if (is.call(template_expr) && template_expr[[1]] == "{") {
@@ -42,6 +44,8 @@ mb_code <- function(template) {
     return(template)
   } else if (grepl("#include <TMB.hpp>", template)) {
     class <- "tmb_code"
+  } else if (grepl("parameters\\s*[{]", template) && identical(stan_engine, "cmdstanr")) {
+    class <- c("smb2_code", "smb_code")
   } else if (grepl("parameters\\s*[{]", template)) {
     class <- "smb_code"
   } else if (grepl("model\\s*[{]", template)) {

--- a/R/model.R
+++ b/R/model.R
@@ -24,6 +24,8 @@
 #' @param new_expr_vec A flag specifying whether to vectorize the new_expr code.
 #' @param modify_new_data A single argument function to modify new data (in list form) immediately prior to calculating new_expr.
 #' @param drops A list of character vector of possible scalar pars to drop (fix at 0).
+#' @param stan_engine A string indicating the Stan engine to use, e.g., `"cmdstanr"`.
+#' Currently, any value other than `"cmdstanr"` will default to `"rstan"`.
 #' @param ... Unused arguments.
 #' @return An object inherting from class mb_model.
 #' @seealso \code{\link[chk]{check_data}} \code{\link[rescale]{rescale_c}}
@@ -44,11 +46,12 @@ model <- function(
     new_expr = NULL,
     new_expr_vec = getOption("mb.new_expr_vec", FALSE),
     modify_new_data = identity,
-    drops = list()) {
+    drops = list(),
+    stan_engine = character(0)) {
   check_dots_empty()
 
   if (is.null(x)) {
-    x <- mb_code({{ code }})
+    x <- mb_code({{ code }}, stan_engine = stan_engine)
   } else {
     chk_null(code)
     if (is.character(x)) {
@@ -58,7 +61,7 @@ model <- function(
         "model(code = 'character()')",
         details = 'Passing a string to model() is deprecated. Use model(code = ...) or model(mb_code("..."), ...) instead.'
       )
-      x <- mb_code(x)
+      x <- mb_code(x, stan_engine = stan_engine)
     } else if (is.mb_analysis(x)) {
       deprecate_soft(
         "0.0.1.9036",

--- a/man/mb_code.Rd
+++ b/man/mb_code.Rd
@@ -5,13 +5,16 @@
 \alias{new_mb_code}
 \title{MB Code}
 \usage{
-mb_code(template)
+mb_code(template, stan_engine = character(0))
 
 new_mb_code(x, class)
 }
 \arguments{
 \item{template}{A string, a braced `{}` expression (unquoted or quoted),
 or an object of class `"mb_code"`.}
+
+\item{stan_engine}{A string indicating the Stan engine to use, e.g., `"cmdstanr"`.
+Currently, any value other than `"cmdstanr"` will assume the engine is `"rstan"`.}
 
 \item{x}{A string or a braced `{}` expression.}
 

--- a/man/mb_code.Rd
+++ b/man/mb_code.Rd
@@ -14,7 +14,7 @@ new_mb_code(x, class)
 or an object of class `"mb_code"`.}
 
 \item{stan_engine}{A string indicating the Stan engine to use, e.g., `"cmdstanr"`.
-Currently, any value other than `"cmdstanr"` will assume the engine is `"rstan"`.}
+Currently, any value other than `"cmdstanr"` will default to `"rstan"`.}
 
 \item{x}{A string or a braced `{}` expression.}
 

--- a/man/model.Rd
+++ b/man/model.Rd
@@ -20,7 +20,8 @@ model(
   new_expr = NULL,
   new_expr_vec = getOption("mb.new_expr_vec", FALSE),
   modify_new_data = identity,
-  drops = list()
+  drops = list(),
+  stan_engine = character(0)
 )
 }
 \arguments{
@@ -57,6 +58,9 @@ returning a named list of initial values.}
 \item{modify_new_data}{A single argument function to modify new data (in list form) immediately prior to calculating new_expr.}
 
 \item{drops}{A list of character vector of possible scalar pars to drop (fix at 0).}
+
+\item{stan_engine}{A string indicating the Stan engine to use, e.g., `"cmdstanr"`.
+Currently, any value other than `"cmdstanr"` will default to `"rstan"`.}
 }
 \value{
 An object inherting from class mb_model.

--- a/tests/testthat/test-mb-code.R
+++ b/tests/testthat/test-mb-code.R
@@ -17,3 +17,8 @@ test_that("expression templates", {
     new_mb_code(quote({}), "pmb_code")
   )
 })
+
+test_that("class smb2_code", {
+  x <- mb_code("parameters{}", stan_engine = "cmdstanr")
+  expect_true(inherits(x, "smb2_code"))
+})

--- a/tests/testthat/test-model-smb2.R
+++ b/tests/testthat/test-model-smb2.R
@@ -1,0 +1,55 @@
+test_that("model pars for smb2", {
+  skip_if_not_installed("smbr")
+
+  template <- "data {
+  int<lower=1> N;
+  vector[N] Year;
+  vector<lower=0>[N] Density;
+}
+
+parameters {
+  real bIntercept;
+  real bYear;
+  real<lower=0> sDensity;
+}
+
+transformed parameters {
+  vector[N] eDensity;
+
+  for(i in 1:N) {
+    eDensity[i] = bIntercept + bYear * Year[i];
+  }
+}
+
+model {
+  bIntercept ~ normal(0, 5);
+  bYear ~ normal(0, 5);
+  sDensity ~ exponential(1);
+
+  Density ~ lognormal(eDensity, sDensity);
+}"
+
+  new_expr <- "
+  for(i in 1:length(Density)) {
+    prediction[i] <- exp(bIntercept + bYear * Year[i])
+} "
+
+  model <- model(
+    code = template,
+    select_data = list(
+      "Year+" = numeric(),
+      Density = numeric()
+    ),
+    fixed = "^(b|l)", derived = "eDensity",
+    new_expr = new_expr,
+    stan_engine = "cmdstanr"
+  )
+
+  expect_identical(class(model), c("smb2_model", "smb_model", "mb_model"))
+
+  expect_identical(length(pars(model, "fixed")), 3L)
+  expect_identical(length(pars(model, "primary")), 3L)
+  expect_identical(pars(model, "random"), character(0))
+  expect_identical(pars(model, "derived"), "eDensity")
+})
+


### PR DESCRIPTION
this paves the way for `smbr2` to use cmdstanr as Stan engine
I added `stan_engine` argument to `mb_code()` and `model()`
default value is character(0), which preserves behaviour.
 if value is "cmdstanr" then sets class to be `c("smb2_code/model", "smb_code/model", "mb_code/model")`

this means that any function making use of the "smb_code/model" class still works but the additional "smb2_code/model" class can be used for a new analyse1 method in smbr2