### PR TITLE
Add directional_information argument to coef() methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     lubridate,
     mcmcdata,
     mcmcderive (>= 0.1.2.9002),
-    mcmcr (>= 0.6.1.9001),
+    mcmcr (>= 0.6.2.9002),
     matrixStats,
     newdata,
     nlist,

--- a/R/coef.R
+++ b/R/coef.R
@@ -1,6 +1,19 @@
 #' @export
 stats::coef
 
+warn_default_directional_information <- function(env = parent.frame(), user_env = parent.frame(2)) {
+  lifecycle::deprecate_soft(
+    "1.1.0",
+    "coef(directional_information = 'should be explicitly set')",
+    details = paste(
+      "The default value of `directional_information` will change from",
+      "`FALSE` to `TRUE` in a future release."
+    ),
+    env = env,
+    user_env = user_env
+  )
+}
+
 get_frequentist_coef <- function(object, conf_level = 0.95) {
   object <- dplyr::mutate(object,
     zscore = .data$estimate / .data$sd,
@@ -16,6 +29,7 @@ coef.mb_null_analysis <- function(object, param_type = "fixed", include_constant
                                   conf_level = getOption("mb.conf_level", 0.95),
                                   estimate = getOption("mb.estimate", median),
                                   simplify = FALSE,
+                                  directional_information = FALSE,
                                   ...) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
@@ -23,6 +37,7 @@ coef.mb_null_analysis <- function(object, param_type = "fixed", include_constant
   chk_number(conf_level)
   chk_range(conf_level, c(0.5, 0.99))
   chk_flag(simplify)
+  chk_flag(directional_information)
 
   coef <- tibble(
     term = as_term(character(0)),
@@ -57,6 +72,12 @@ coef.mb_null_analysis <- function(object, param_type = "fixed", include_constant
 #' @param conf_level A number specifying the confidence level. By default 0.95.
 #' @param estimate The function to use to calculating the estimate for Bayesian models.
 #' @param simplify A flag specifying whether to drop sd and zscore columns and return svalue instead of pvalue.
+#' @param directional_information A flag specifying whether the svalue column
+#' for a Bayesian analysis should be calculated using
+#' [extras::directional_information()] instead of [extras::svalue()].
+#' The default value will change from `FALSE` to `TRUE` in a future release;
+#' set the argument explicitly to avoid the deprecation warning.
+#' Ignored for frequentist analyses where the svalue is always `-log2(pvalue)`.
 #' @param ... Not used.
 #' @return A tidy tibble of the coefficient terms.
 #' @export
@@ -64,6 +85,7 @@ coef.mb_analysis <- function(object, param_type = "fixed", include_constant = TR
                              conf_level = getOption("mb.conf_level", 0.95),
                              estimate = getOption("mb.estimate", median),
                              simplify = FALSE,
+                             directional_information = FALSE,
                              ...) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
@@ -71,6 +93,11 @@ coef.mb_analysis <- function(object, param_type = "fixed", include_constant = TR
   chk_number(conf_level)
   chk_range(conf_level, c(0.5, 0.99))
   chk_flag(simplify)
+  chk_flag(directional_information)
+
+  if (simplify && missing(directional_information) && is_bayesian(object)) {
+    warn_default_directional_information()
+  }
 
   pars <- pars(object, param_type)
 
@@ -98,17 +125,20 @@ coef.mb_analysis <- function(object, param_type = "fixed", include_constant = TR
   if (is_bayesian(object)) {
     coef <- as.mcmcr(object)
     coef <- subset(coef, pars = pars)
-    coef <- coef(coef, estimate = estimate, simplify = simplify)
+    coef <- coef(coef,
+      estimate = estimate, simplify = simplify,
+      directional_information = directional_information
+    )
 
     if (!include_constant) coef <- dplyr::filter(coef, .data$lower != .data$upper)
   } else {
     coef <- as.mcmcr(object)
     coef <- subset(coef, pars = pars)
-    coef <- coef(coef)
+    coef <- coef(coef, directional_information = FALSE)
 
     sd <- as.mcmcr(object$sd)
     sd <- subset(sd, pars = pars)
-    sd <- coef(sd)
+    sd <- coef(sd, directional_information = FALSE)
 
     coef$sd <- sd$estimate
 

--- a/R/terms.R
+++ b/R/terms.R
@@ -22,5 +22,8 @@ nterms.mb_analysis <- function(x, param_type = "fixed", include_constant = TRUE,
 #' @param ... Not used.
 #' @export
 terms.mb_analysis <- function(x, param_type = "fixed", include_constant = TRUE, ...) {
-  coef(x, param_type = param_type, include_constant = include_constant, simplify = TRUE)$term
+  coef(x,
+    param_type = param_type, include_constant = include_constant,
+    simplify = TRUE, directional_information = FALSE
+  )$term
 }

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -3,7 +3,10 @@ generics::tidy
 
 #' @export
 tidy.mb_analysis <- function(x, conf_level = getOption("mb.conf_level", 0.95), ...) {
-  coef <- coef(x, conf_level = conf_level, beep = FALSE, simplify = TRUE)
+  coef <- coef(x,
+    conf_level = conf_level, beep = FALSE, simplify = TRUE,
+    directional_information = FALSE
+  )
 
   coef <- coef[c("term", "estimate", "lower", "upper")]
 

--- a/man/coef.mb_analysis.Rd
+++ b/man/coef.mb_analysis.Rd
@@ -11,6 +11,7 @@
   conf_level = getOption("mb.conf_level", 0.95),
   estimate = getOption("mb.estimate", median),
   simplify = FALSE,
+  directional_information = FALSE,
   ...
 )
 }
@@ -26,6 +27,13 @@
 \item{estimate}{The function to use to calculating the estimate for Bayesian models.}
 
 \item{simplify}{A flag specifying whether to drop sd and zscore columns and return svalue instead of pvalue.}
+
+\item{directional_information}{A flag specifying whether the svalue column
+for a Bayesian analysis should be calculated using
+\code{\link[extras:directional_information]{extras::directional_information()}} instead of \code{\link[extras:svalue]{extras::svalue()}}.
+The default value will change from \code{FALSE} to \code{TRUE} in a future release;
+set the argument explicitly to avoid the deprecation warning.
+Ignored for frequentist analyses where the svalue is always \code{-log2(pvalue)}.}
 
 \item{...}{Not used.}
 }

--- a/tests/testthat/test-coef.R
+++ b/tests/testthat/test-coef.R
@@ -1,0 +1,44 @@
+test_that("coef directional_information for Bayesian analysis", {
+  analysis <- readRDS(
+    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+  )
+
+  coef_svalue <- coef(analysis, simplify = TRUE, directional_information = FALSE)
+  expect_identical(colnames(coef_svalue), c("term", "estimate", "lower", "upper", "svalue"))
+
+  coef_di <- coef(analysis, simplify = TRUE, directional_information = TRUE)
+  expect_identical(colnames(coef_di), c("term", "estimate", "lower", "upper", "svalue"))
+
+  expect_identical(
+    coef_di[c("term", "estimate", "lower", "upper")],
+    coef_svalue[c("term", "estimate", "lower", "upper")]
+  )
+  expect_false(identical(coef_di$svalue, coef_svalue$svalue))
+
+  mcmcr <- subset(as.mcmcr(analysis), pars = pars(analysis, "fixed"))
+  expect_identical(
+    coef_di$svalue,
+    coef(mcmcr, directional_information = TRUE)$svalue
+  )
+})
+
+test_that("coef soft-deprecates unset directional_information for Bayesian analysis", {
+  analysis <- readRDS(
+    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+  )
+
+  lifecycle::expect_deprecated(coef(analysis, simplify = TRUE))
+  expect_no_warning(coef(analysis, simplify = TRUE, directional_information = FALSE))
+  expect_no_warning(coef(analysis, simplify = TRUE, directional_information = TRUE))
+
+  chk::expect_chk_error(coef(analysis, directional_information = NA))
+})
+
+test_that("coef directional_information for null analysis", {
+  analysis <- list(data = datasets::mtcars)
+  class(analysis) <- c("mb_null_analysis", "mb_analysis")
+
+  coef <- coef(analysis, simplify = TRUE, directional_information = TRUE)
+  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(nrow(coef), 0L)
+})

--- a/tests/testthat/test-zzz-analyse-cmdstan.R
+++ b/tests/testthat/test-zzz-analyse-cmdstan.R
@@ -110,10 +110,10 @@ model {
     glance <- glance(analysis)
     expect_snapshot(glance)
 
-    coef <- coef(analysis, simplify = TRUE)
+    coef <- coef(analysis, simplify = TRUE, directional_information = FALSE)
     expect_snapshot(coef)
 
-    derived <- coef(analysis, param_type = "derived", simplify = TRUE)
+    derived <- coef(analysis, param_type = "derived", simplify = TRUE, directional_information = FALSE)
     expect_snapshot(derived)
 
     tidy <- tidy(analysis)

--- a/tests/testthat/test-zzz-analyse-rstan.R
+++ b/tests/testthat/test-zzz-analyse-rstan.R
@@ -110,10 +110,10 @@ model {
     glance <- glance(analysis)
     expect_snapshot(glance)
 
-    coef <- coef(analysis, simplify = TRUE)
+    coef <- coef(analysis, simplify = TRUE, directional_information = FALSE)
     expect_snapshot(coef)
 
-    derived <- coef(analysis, param_type = "derived", simplify = TRUE)
+    derived <- coef(analysis, param_type = "derived", simplify = TRUE, directional_information = FALSE)
     expect_snapshot(derived)
 
     tidy <- tidy(analysis)

--- a/tests/testthat/test-zzz-analyse.R
+++ b/tests/testthat/test-zzz-analyse.R
@@ -102,11 +102,11 @@ test_that("analyse", {
   expect_identical(glance$nthin, 1L)
   expect_identical(glance$K, 5L)
 
-  derived <- coef(analysis, param_type = "derived", simplify = TRUE)
+  derived <- coef(analysis, param_type = "derived", simplify = TRUE, directional_information = FALSE)
   expect_identical(colnames(derived), c("term", "estimate", "lower", "upper", "svalue"))
   expect_identical(nrow(derived), 300L)
 
-  coef <- coef(analysis, simplify = TRUE)
+  coef <- coef(analysis, simplify = TRUE, directional_information = FALSE)
 
   expect_s3_class(coef, "tbl")
   expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
@@ -117,8 +117,8 @@ test_that("analyse", {
     "log_sDensity", "log_sSiteYear"
   )))
 
-  expect_identical(nrow(coef(analysis, "primary", simplify = TRUE)), 66L)
-  expect_identical(nrow(coef(analysis, "all", simplify = TRUE)), 366L)
+  expect_identical(nrow(coef(analysis, "primary", simplify = TRUE, directional_information = FALSE)), 66L)
+  expect_identical(nrow(coef(analysis, "all", simplify = TRUE, directional_information = FALSE)), 366L)
 
   tidy <- tidy(analysis)
   expect_identical(colnames(tidy), c("term", "estimate", "lower", "upper", "esr", "rhat"))

--- a/vignettes/articles/analyse.Rmd
+++ b/vignettes/articles/analyse.Rmd
@@ -255,7 +255,7 @@ glance(analysis)
 `coef()` extracts the fixed-effect and scale parameters:
 
 ```{r coef}
-coef(analysis, include_constant = FALSE, simplify = TRUE) |>
+coef(analysis, include_constant = FALSE, simplify = TRUE, directional_information = FALSE) |>
   mutate(across(estimate:svalue, ~ signif(.x, 3)))
 ```
 
@@ -355,7 +355,7 @@ analysis_pf <- analyse(
   beep = FALSE
 )
 
-coef(analysis_pf, include_constant = FALSE, simplify = TRUE) |>
+coef(analysis_pf, include_constant = FALSE, simplify = TRUE, directional_information = FALSE) |>
   filter(term %in% c("bIntercept", "bTreatment_dev[1]", "bTemp")) |>
   mutate(across(estimate:svalue, ~ signif(.x, 3)))
 ```

--- a/vignettes/articles/prediction.Rmd
+++ b/vignettes/articles/prediction.Rmd
@@ -202,7 +202,7 @@ analysis <- analyse(
   beep = FALSE
 )
 
-coef(analysis, include_constant = FALSE, simplify = TRUE) |>
+coef(analysis, include_constant = FALSE, simplify = TRUE, directional_information = FALSE) |>
   mutate(across(estimate:svalue, ~ signif(.x, 3)))
 ```
 


### PR DESCRIPTION
Closes #116. Companion PR: poissonconsulting/mcmcr#71 (must be merged first).

## Changes

- `coef.mb_analysis()` and `coef.mb_null_analysis()` gain a `directional_information = FALSE` argument.
- For Bayesian analyses with `simplify = TRUE` and `directional_information = TRUE` the `svalue` column is calculated using `extras::directional_information()` instead of `extras::svalue()` (passed through to `mcmcr::coef()`). The column name is unchanged.
- When `simplify = TRUE` for a Bayesian analysis and the user has not explicitly set `directional_information`, `lifecycle::deprecate_soft()` warns that the default will change from `FALSE` to `TRUE` in a future release (`when = "1.1.0"`). Setting the argument explicitly (either value) silences the warning.
- Frequentist (ML) analyses are unaffected: the svalue remains `-log2(pvalue)` from the normal approximation, the argument is ignored, and no deprecation warning is issued (as agreed).
- Internal callers (`tidy.mb_analysis()`, `terms.mb_analysis()`, the frequentist branch of `coef.mb_analysis()`) now set the argument explicitly so they neither warn nor change behaviour when the default flips.
- Integration tests and the analyse/prediction articles set `directional_information = FALSE` explicitly.
- New unit tests (using the pre-computed JAGS test object) cover column stability, value pass-through to mcmcr, the deprecation warning, and input checking.
- Requires `mcmcr (>= 0.6.2.9002)`, the version on the companion branch, so CI will fail until mcmcr#71 is merged.

## Notes

- The uncommitted roxygen reformatting of NAMESPACE/man on local main was left out of this PR.
- Full local test suite: 3 pre-existing failures in test-zzz-analyse-cmdstan.R from 7th-decimal snapshot drift under a newer CmdStan; unrelated and not accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)