### PR TITLE
Standardize CI (tier: important)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yaml@v1
     with:
       tier: important
-      jags: false
+      jags: true
       tex: false
       private: false
     secrets: inherit

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -13,5 +13,6 @@ jobs:
   pkgdown:
     uses: poissonconsulting/.github/.github/workflows/pkgdown.yaml@v1
     with:
+      cmdstan: true
       private: false
     secrets: inherit


### PR DESCRIPTION
Standardizes CI onto the reusable workflows in `poissonconsulting/.github` (tier **important**, private=false, jags=true, cmdstan=true, tex=false). Callers: R-CMD-check, test-coverage, pkgdown; fledge callers unchanged.