### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,5 @@
 ^vignettes/articles$
 ^\.claude$
 ^CLAUDE\.md$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/IC.R
+++ b/R/IC.R
@@ -38,24 +38,38 @@ IC.mb_analysis <- function(object, ...) {
 IC.mb_analyses <- function(object, ...) {
   if (!length(object)) {
     return(tibble(
-      model = character(0), K = integer(0), IC = numeric(0),
-      DeltaIC = numeric(0), ICWt = numeric(0)
+      model = character(0),
+      K = integer(0),
+      IC = numeric(0),
+      DeltaIC = numeric(0),
+      ICWt = numeric(0)
     ))
   }
   if (!all(vapply(object, is.mb_analysis, TRUE))) {
     err("object must be a list of mb_analysis objects", tidy = FALSE)
   }
 
-  if (is.null(names(object))) names(object) <- 1:length(object)
+  if (is.null(names(object))) {
+    names(object) <- 1:length(object)
+  }
 
-  if (anyDuplicated(names(object))) err("objects must be uniquely named", tidy = FALSE)
+  if (anyDuplicated(names(object))) {
+    err("objects must be uniquely named", tidy = FALSE)
+  }
 
   data <- lapply(object, data_set)
-  if (!all(vapply(data, identical, TRUE, data[[1]]))) err("all elements of object must have the same data", tidy = FALSE)
+  if (!all(vapply(data, identical, TRUE, data[[1]]))) {
+    err("all elements of object must have the same data", tidy = FALSE)
+  }
 
   random_effects <- lapply(object, random_effects)
   random_effects <- lapply(random_effects, sort_random_effects)
-  if (!all(vapply(data, identical, TRUE, data[[1]]))) err("all elements of object must have the same random effects", tidy = FALSE)
+  if (!all(vapply(data, identical, TRUE, data[[1]]))) {
+    err(
+      "all elements of object must have the same random effects",
+      tidy = FALSE
+    )
+  }
 
   tibble <- tibble(model = names(object))
   tibble$K <- vapply(object, nterms, 1L, include_constant = FALSE)

--- a/R/R2.R
+++ b/R/R2.R
@@ -25,11 +25,15 @@ R2 <- function(object, ...) {
 #'
 #' @return A number of the R2 value.
 #' @export
-R2.mb_analysis <- function(object, response, marginal = FALSE,
-                           term = "prediction",
-                           parallel = getOption("mb.parallel", FALSE),
-                           quiet = getOption("mb.quiet", TRUE),
-                           ...) {
+R2.mb_analysis <- function(
+  object,
+  response,
+  marginal = FALSE,
+  term = "prediction",
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  ...
+) {
   chk_string(response)
   chk_flag(marginal)
 
@@ -38,10 +42,15 @@ R2.mb_analysis <- function(object, response, marginal = FALSE,
 
   new_data <- data_set(object, marginalize_random_effects = marginal)
 
-  prediction <- predict(object,
-    new_data = new_data, term = term,
-    parallel = parallel, quiet = quiet
+  prediction <- predict(
+    object,
+    new_data = new_data,
+    term = term,
+    parallel = parallel,
+    quiet = quiet
   )
 
-  1 - stats::var(data[[response]] - prediction$estimate) / stats::var(data[[response]])
+  1 -
+    stats::var(data[[response]] - prediction$estimate) /
+      stats::var(data[[response]])
 }

--- a/R/add-sensitivity.R
+++ b/R/add-sensitivity.R
@@ -16,7 +16,12 @@ add_sensitivity <- function(x, new_expr = NULL, replace = FALSE, ...) {
 }
 
 #' @export
-add_sensitivity.mb_analysis <- function(x, new_expr = NULL, replace = FALSE, ...) {
+add_sensitivity.mb_analysis <- function(
+  x,
+  new_expr = NULL,
+  replace = FALSE,
+  ...
+) {
   check_mb_analysis(x)
   chk_flag(replace)
 

--- a/R/add.R
+++ b/R/add.R
@@ -5,8 +5,12 @@
 #' @return An object of class mb_models.
 #' @export
 add_models <- function(x, x2) {
-  if (is.mb_model(x)) x <- list(x)
-  if (is.mb_model(x2)) x2 <- list(x2)
+  if (is.mb_model(x)) {
+    x <- list(x)
+  }
+  if (is.mb_model(x2)) {
+    x2 <- list(x2)
+  }
   x <- c(x, x2)
   as.models(x)
 }
@@ -18,8 +22,12 @@ add_models <- function(x, x2) {
 #' @return An object of class mb_analyses.
 #' @export
 add_analyses <- function(x, x2) {
-  if (is.mb_analysis(x)) x <- list(x)
-  if (is.mb_analysis(x2)) x2 <- list(x2)
+  if (is.mb_analysis(x)) {
+    x <- list(x)
+  }
+  if (is.mb_analysis(x2)) {
+    x2 <- list(x2)
+  }
   x <- c(x, x2)
   as.analyses(x)
 }

--- a/R/analyse.R
+++ b/R/analyse.R
@@ -141,30 +141,88 @@ analyse <- function(x, ...) {
 #' @return An `mb_analysis` object.
 #' @keywords internal
 #' @export
-analyse1 <- function(model, data, loaded, nchains, niters, nthin, quiet, glance, parallel, seed, niters_warmup, ...) {
+analyse1 <- function(
+  model,
+  data,
+  loaded,
+  nchains,
+  niters,
+  nthin,
+  quiet,
+  glance,
+  parallel,
+  seed,
+  niters_warmup,
+  ...
+) {
   UseMethod("analyse1")
 }
 
-analyse_data <- function(data, name = NULL, x, loaded, nchains, niters, nthin,
-                         parallel, quiet, glance, seed, niters_warmup, ...) {
+analyse_data <- function(
+  data,
+  name = NULL,
+  x,
+  loaded,
+  nchains,
+  niters,
+  nthin,
+  parallel,
+  quiet,
+  glance,
+  seed,
+  niters_warmup,
+  ...
+) {
   check_no_sf(data)
-  if (!is.null(name) & glance) cat("Data:", name, "\n")
-  analyse1(x, data,
-    loaded = loaded, nchains = nchains, niters = niters,
-    nthin = nthin, parallel = parallel, quiet = quiet,
-    glance = glance, seed = seed,
-    niters_warmup = niters_warmup, ...
+  if (!is.null(name) & glance) {
+    cat("Data:", name, "\n")
+  }
+  analyse1(
+    x,
+    data,
+    loaded = loaded,
+    nchains = nchains,
+    niters = niters,
+    nthin = nthin,
+    parallel = parallel,
+    quiet = quiet,
+    glance = glance,
+    seed = seed,
+    niters_warmup = niters_warmup,
+    ...
   )
 }
 
 
-analyse_model <- function(x, name = NULL, data, parallel, nchains, niters, nthin, quiet, glance, beep, stan_engine, ...) {
-  if (!is.null(name) & glance) cat("Model:", name, "\n")
-  analyse(x,
-    data = data, parallel = parallel,
-    nchains = nchains, niters = niters, nthin = nthin,
-    quiet = quiet, glance = glance, beep = beep,
-    stan_engine = stan_engine, ...
+analyse_model <- function(
+  x,
+  name = NULL,
+  data,
+  parallel,
+  nchains,
+  niters,
+  nthin,
+  quiet,
+  glance,
+  beep,
+  stan_engine,
+  ...
+) {
+  if (!is.null(name) & glance) {
+    cat("Model:", name, "\n")
+  }
+  analyse(
+    x,
+    data = data,
+    parallel = parallel,
+    nchains = nchains,
+    niters = niters,
+    nthin = nthin,
+    quiet = quiet,
+    glance = glance,
+    beep = beep,
+    stan_engine = stan_engine,
+    ...
   )
 }
 
@@ -185,44 +243,61 @@ analyse_model <- function(x, name = NULL, data, parallel, nchains, niters, nthin
 #' @return An `mb_analysis` or `mb_meta_analysis`. See [analyse()] for details.
 #' @seealso [analyse()] for full argument documentation and engine details.
 #' @export
-analyse.character <- function(x, data,
-                              select_data = list(),
-                              nchains = getOption("mb.nchains", 3L),
-                              niters = getOption("mb.niters", 1000L),
-                              nthin = getOption("mb.nthin", 1L),
-                              parallel = getOption("mb.parallel", FALSE),
-                              quiet = getOption("mb.quiet", TRUE),
-                              glance = getOption("mb.glance", TRUE),
-                              beep = getOption("mb.beep", TRUE),
-                              seed = sample.int(.Machine$integer.max, 1),
-                              stan_engine = getOption("mb.stan_engine", character(0)),
-                              niters_warmup = niters,
-                              ...) {
+analyse.character <- function(
+  x,
+  data,
+  select_data = list(),
+  nchains = getOption("mb.nchains", 3L),
+  niters = getOption("mb.niters", 1000L),
+  nthin = getOption("mb.nthin", 1L),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  seed = sample.int(.Machine$integer.max, 1),
+  stan_engine = getOption("mb.stan_engine", character(0)),
+  niters_warmup = niters,
+  ...
+) {
   x <- model(x, select_data = select_data)
-  analyse(x,
+  analyse(
+    x,
     data = data,
-    parallel = parallel, nchains = nchains, niters = niters, nthin = nthin, quiet = quiet,
-    glance = glance, beep = beep, seed = seed, stan_engine = stan_engine,
-    niters_warmup = niters_warmup, ...
+    parallel = parallel,
+    nchains = nchains,
+    niters = niters,
+    nthin = nthin,
+    quiet = quiet,
+    glance = glance,
+    beep = beep,
+    seed = seed,
+    stan_engine = stan_engine,
+    niters_warmup = niters_warmup,
+    ...
   )
 }
 
 #' @rdname analyse
 #' @export
-analyse.mb_model <- function(x, data,
-                             nchains = getOption("mb.nchains", 3L),
-                             niters = getOption("mb.niters", 1000L),
-                             nthin = getOption("mb.thin", NULL),
-                             parallel = getOption("mb.parallel", FALSE),
-                             quiet = getOption("mb.quiet", TRUE),
-                             glance = getOption("mb.glance", TRUE),
-                             beep = getOption("mb.beep", TRUE),
-                             seed = sample.int(.Machine$integer.max, 1),
-                             stan_engine = getOption("mb.stan_engine", character(0)),
-                             niters_warmup = niters,
-                             ...) {
+analyse.mb_model <- function(
+  x,
+  data,
+  nchains = getOption("mb.nchains", 3L),
+  niters = getOption("mb.niters", 1000L),
+  nthin = getOption("mb.thin", NULL),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  seed = sample.int(.Machine$integer.max, 1),
+  stan_engine = getOption("mb.stan_engine", character(0)),
+  niters_warmup = niters,
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
 
   if (is.data.frame(data)) {
     chk_data(data)
@@ -250,7 +325,9 @@ analyse.mb_model <- function(x, data,
   chk_whole_number(niters_warmup)
   chk_range(niters_warmup, c(10L, 100000L))
 
-  if (is.null(nthin)) nthin <- nthin(x)
+  if (is.null(nthin)) {
+    nthin <- nthin(x)
+  }
 
   if (identical(stan_engine, "cmdstan-mcmc")) {
     class(x) <- c("cmdstan_model", "cmdstan_mcmc_model", class(x))
@@ -268,11 +345,18 @@ analyse.mb_model <- function(x, data,
 
   if (is.data.frame(data)) {
     return(analyse_data(
-      data = data, x = x, loaded = loaded,
-      nchains = nchains, niters = niters, nthin = nthin,
-      parallel = parallel, quiet = quiet, glance = glance,
+      data = data,
+      x = x,
+      loaded = loaded,
+      nchains = nchains,
+      niters = niters,
+      nthin = nthin,
+      parallel = parallel,
+      quiet = quiet,
+      glance = glance,
       seed = seed,
-      niters_warmup = niters_warmup, ...
+      niters_warmup = niters_warmup,
+      ...
     ))
   }
 
@@ -281,12 +365,21 @@ analyse.mb_model <- function(x, data,
     names(data) <- seq_along(data)
   }
 
-  analyses <- purrr::imap(data, analyse_data,
-    x = x, loaded = loaded,
-    nchains = nchains, niters = niters, nthin = nthin,
-    parallel = parallel, quiet = quiet, glance = glance,
-    seed = seed, stan_engine = stan_engine,
-    niters_warmup = niters_warmup, ...
+  analyses <- purrr::imap(
+    data,
+    analyse_data,
+    x = x,
+    loaded = loaded,
+    nchains = nchains,
+    niters = niters,
+    nthin = nthin,
+    parallel = parallel,
+    quiet = quiet,
+    glance = glance,
+    seed = seed,
+    stan_engine = stan_engine,
+    niters_warmup = niters_warmup,
+    ...
   )
 
   names(data) <- names
@@ -308,30 +401,46 @@ analyse.mb_model <- function(x, data,
 #'   data frames).
 #' @seealso [analyse()] for full argument documentation and engine details.
 #' @export
-analyse.mb_models <- function(x, data,
-                              nchains = getOption("mb.nchains", 3L),
-                              niters = getOption("mb.niters", 1000L),
-                              nthin = getOption("mb.thin", NULL),
-                              parallel = getOption("mb.parallel", FALSE),
-                              quiet = getOption("mb.quiet", TRUE),
-                              glance = getOption("mb.glance", TRUE),
-                              beep = getOption("mb.beep", TRUE),
-                              seed = sample.int(.Machine$integer.max, 1),
-                              stan_engine = getOption("mb.stan_engine", character(0)),
-                              niters_warmup = niters,
-                              ...) {
+analyse.mb_models <- function(
+  x,
+  data,
+  nchains = getOption("mb.nchains", 3L),
+  niters = getOption("mb.niters", 1000L),
+  nthin = getOption("mb.thin", NULL),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  seed = sample.int(.Machine$integer.max, 1),
+  stan_engine = getOption("mb.stan_engine", character(0)),
+  niters_warmup = niters,
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
 
   names <- names(x)
-  if (is.null(names)) names(x) <- seq_along(x)
+  if (is.null(names)) {
+    names(x) <- seq_along(x)
+  }
 
-  analyses <- purrr::imap(x, analyse_model,
+  analyses <- purrr::imap(
+    x,
+    analyse_model,
     data = data,
-    nchains = nchains, niters = niters, nthin = nthin,
-    parallel = parallel, quiet = quiet, glance = glance, beep = FALSE,
-    seed = seed, stan_engine = stan_engine,
-    niters_warmup = niters_warmup, ...
+    nchains = nchains,
+    niters = niters,
+    nthin = nthin,
+    parallel = parallel,
+    quiet = quiet,
+    glance = glance,
+    beep = FALSE,
+    seed = seed,
+    stan_engine = stan_engine,
+    niters_warmup = niters_warmup,
+    ...
   )
 
   if (is.data.frame(data)) {

--- a/R/as.R
+++ b/R/as.R
@@ -66,7 +66,9 @@ as.models.mb_model <- function(x, ...) {
 #' @export
 as.models.list <- function(x, ...) {
   chk_unused(...)
-  if (!is.list(x)) err("x must be a list", tidy = FALSE)
+  if (!is.list(x)) {
+    err("x must be a list", tidy = FALSE)
+  }
 
   if (length(x)) {
     if (!all(purrr::map_lgl(x, is.mb_model))) {
@@ -105,7 +107,9 @@ as.mcmcrs.mb_analyses <- function(x, ...) {
 #' @export
 as.analyses.list <- function(x, ...) {
   chk_unused(...)
-  if (!is.list(x)) err("x must be a list", tidy = FALSE)
+  if (!is.list(x)) {
+    err("x must be a list", tidy = FALSE)
+  }
 
   if (length(x)) {
     if (!all(purrr::map_lgl(x, is.mb_analysis))) {

--- a/R/augment.R
+++ b/R/augment.R
@@ -19,7 +19,11 @@ augment.mb_analysis <- function(x, ...) {
         data$vlog_lik <- apply(logLik, 2, var)
       }
     } else {
-      data$log_lik <- predict(x, new_data = data_set(x), term = "log_lik")$estimate
+      data$log_lik <- predict(
+        x,
+        new_data = data_set(x),
+        term = "log_lik"
+      )$estimate
     }
   }
   data

--- a/R/backwards.R
+++ b/R/backwards.R
@@ -16,20 +16,36 @@
 #' @param ... Unused.
 #' @return A list of the analyses.
 #' @export
-backwards <- function(model, data, drops = list(), conf_level = getOption("mb.conf_level", 0.95),
-                      beep = getOption("mb.beep", TRUE), ...) {
+backwards <- function(
+  model,
+  data,
+  drops = list(),
+  conf_level = getOption("mb.conf_level", 0.95),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   UseMethod("backwards")
 }
 
 #' @export
-backwards.mb_model <- function(model, data, drops = list(), conf_level = getOption("mb.conf_level", 0.95),
-                               beep = getOption("mb.beep", TRUE), ...) {
+backwards.mb_model <- function(
+  model,
+  data,
+  drops = list(),
+  conf_level = getOption("mb.conf_level", 0.95),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   .NotYetImplemented()
 
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep(2))
+  if (beep) {
+    on.exit(beepr::beep(2))
+  }
 
-  if (!length(drops)) drops <- model$drops
+  if (!length(drops)) {
+    drops <- model$drops
+  }
 
   drops_org <- drops
 

--- a/R/base-model.R
+++ b/R/base-model.R
@@ -8,6 +8,8 @@ base_model <- function(model, drops = list()) {
   check_mb_model(model)
   check_drops(drops)
 
-  if (!length(drops)) drops <- model$drops
+  if (!length(drops)) {
+    drops <- model$drops
+  }
   drop_pars(model, full_drop(drops))
 }

--- a/R/check.R
+++ b/R/check.R
@@ -1,5 +1,7 @@
 check_drops <- function(drops) {
-  if (!is.list(drops)) err("drops must be a list", tidy = FALSE)
+  if (!is.list(drops)) {
+    err("drops must be a list", tidy = FALSE)
+  }
   if (!length(drops)) {
     return(drops)
   }
@@ -7,7 +9,10 @@ check_drops <- function(drops) {
     err("drops must be a list of character vectors", tidy = FALSE)
   }
   if (!all(vapply(drops, length, 1L) > 0)) {
-    err("drops must be a list of non-zero length character vectors", tidy = FALSE)
+    err(
+      "drops must be a list of non-zero length character vectors",
+      tidy = FALSE
+    )
   }
   if (anyDuplicated(drops)) {
     err("drops must be a list of unique character vectors", tidy = FALSE)
@@ -26,9 +31,13 @@ check_drops <- function(drops) {
 #' @return The object or throws an informative error.
 #' @export
 check_mb_code <- function(object, object_name = substitute(object)) {
-  if (!is.character(object_name)) object_name <- deparse(object_name)
+  if (!is.character(object_name)) {
+    object_name <- deparse(object_name)
+  }
 
-  if (!is.mb_code(object)) err(object_name, " must inherit from class mb_code", tidy = FALSE)
+  if (!is.mb_code(object)) {
+    err(object_name, " must inherit from class mb_code", tidy = FALSE)
+  }
   object
 }
 
@@ -39,9 +48,13 @@ check_mb_code <- function(object, object_name = substitute(object)) {
 #' @return The object or throws an informative error.
 #' @export
 check_mb_analysis <- function(object, object_name = substitute(object)) {
-  if (!is.character(object_name)) object_name <- deparse(object_name)
+  if (!is.character(object_name)) {
+    object_name <- deparse(object_name)
+  }
 
-  if (!is.mb_analysis(object)) err(object_name, " must inherit from class mb_analysis", tidy = FALSE)
+  if (!is.mb_analysis(object)) {
+    err(object_name, " must inherit from class mb_analysis", tidy = FALSE)
+  }
   object
 }
 
@@ -52,15 +65,30 @@ check_mb_analysis <- function(object, object_name = substitute(object)) {
 #' @return The object or throws an informative error.
 #' @export
 check_mb_model <- function(object, object_name = substitute(object)) {
-  if (!is.character(object_name)) object_name <- deparse(object_name)
+  if (!is.character(object_name)) {
+    object_name <- deparse(object_name)
+  }
 
-  if (!is.mb_model(object)) err(object_name, " must inherit from class mb_model", tidy = FALSE)
+  if (!is.mb_model(object)) {
+    err(object_name, " must inherit from class mb_model", tidy = FALSE)
+  }
   object
 }
 
-check_x_in_y <- function(x, y, x_name = substitute(x), y_name = substitute(y), type_x = "values", type_y = "values") {
-  if (is.name(x_name)) x_name <- deparse(x_name)
-  if (is.name(y_name)) y_name <- deparse(y_name)
+check_x_in_y <- function(
+  x,
+  y,
+  x_name = substitute(x),
+  y_name = substitute(y),
+  type_x = "values",
+  type_y = "values"
+) {
+  if (is.name(x_name)) {
+    x_name <- deparse(x_name)
+  }
+  if (is.name(y_name)) {
+    y_name <- deparse(y_name)
+  }
 
   if (is.null(y)) {
     return(x)
@@ -70,14 +98,34 @@ check_x_in_y <- function(x, y, x_name = substitute(x), y_name = substitute(y), t
   }
 
   if (!all(x %in% y)) {
-    err(type_x, " in ", x_name, " must also be in ", type_y, " of ", y_name, tidy = FALSE)
+    err(
+      type_x,
+      " in ",
+      x_name,
+      " must also be in ",
+      type_y,
+      " of ",
+      y_name,
+      tidy = FALSE
+    )
   }
   x
 }
 
-check_x_not_in_y <- function(x, y, x_name = substitute(x), y_name = substitute(y), type_x = "values", type_y = "values") {
-  if (is.name(x_name)) x_name <- deparse(x_name)
-  if (is.name(y_name)) y_name <- deparse(y_name)
+check_x_not_in_y <- function(
+  x,
+  y,
+  x_name = substitute(x),
+  y_name = substitute(y),
+  type_x = "values",
+  type_y = "values"
+) {
+  if (is.name(x_name)) {
+    x_name <- deparse(x_name)
+  }
+  if (is.name(y_name)) {
+    y_name <- deparse(y_name)
+  }
 
   if (is.null(y)) {
     return(x)
@@ -87,7 +135,16 @@ check_x_not_in_y <- function(x, y, x_name = substitute(x), y_name = substitute(y
   }
 
   if (any(x %in% y)) {
-    err(type_x, " in ", x_name, " must not be in ", type_y, " of ", y_name, tidy = FALSE)
+    err(
+      type_x,
+      " in ",
+      x_name,
+      " must not be in ",
+      type_y,
+      " of ",
+      y_name,
+      tidy = FALSE
+    )
   }
   x
 }
@@ -95,8 +152,12 @@ check_x_not_in_y <- function(x, y, x_name = substitute(x), y_name = substitute(y
 check_single_arg_fun <- function(fun) {
   fun_name <- deparse(substitute(fun))
 
-  if (!is.function(fun)) err(fun_name, " must be a function", tidy = FALSE)
-  if (length(formals(args(fun))) != 1) err(fun_name, " must take a single argument", tidy = FALSE)
+  if (!is.function(fun)) {
+    err(fun_name, " must be a function", tidy = FALSE)
+  }
+  if (length(formals(args(fun))) != 1) {
+    err(fun_name, " must take a single argument", tidy = FALSE)
+  }
   fun
 }
 
@@ -108,15 +169,21 @@ check_unique_character_vector <- function(x, x_name = substitute(x)) {
 }
 
 check_uniquely_named_character_vector <- function(x, x_name = substitute(x)) {
-  if (is.name(x)) x_name <- deparse(x_name)
+  if (is.name(x)) {
+    x_name <- deparse(x_name)
+  }
 
-  if (!is.character(x)) err(x_name, " must be a character vector", tidy = FALSE)
+  if (!is.character(x)) {
+    err(x_name, " must be a character vector", tidy = FALSE)
+  }
 
   if (!length(x)) {
     return(x)
   }
 
-  if (is.null(names(x))) err(x_name, "must be named", tidy = FALSE)
+  if (is.null(names(x))) {
+    err(x_name, "must be named", tidy = FALSE)
+  }
   chk_unique(names(x), x_name = x_name)
   x
 }
@@ -128,19 +195,29 @@ check_uniquely_named_character_vector <- function(x, x_name = substitute(x)) {
 #' @return The original object or throws an informative error.
 #' @export
 check_uniquely_named_list <- function(x, x_name = substitute(x)) {
-  if (is.name(x)) x_name <- deparse(x_name)
+  if (is.name(x)) {
+    x_name <- deparse(x_name)
+  }
 
-  if (!is.list(x)) err(x_name, " must be a list", tidy = FALSE)
+  if (!is.list(x)) {
+    err(x_name, " must be a list", tidy = FALSE)
+  }
   if (!length(x)) {
     return(x)
   }
-  if (is.null(names(x))) err(x_name, " must be a named list", tidy = FALSE)
-  if (anyDuplicated(names(x))) err(x_name, " must be a uniquely named list", tidy = FALSE)
+  if (is.null(names(x))) {
+    err(x_name, " must be a named list", tidy = FALSE)
+  }
+  if (anyDuplicated(names(x))) {
+    err(x_name, " must be a uniquely named list", tidy = FALSE)
+  }
   x
 }
 
 check_all_elements_class_character <- function(x, x_name = substitute(x)) {
-  if (is.name(x)) x_name <- deparse(x_name)
+  if (is.name(x)) {
+    x_name <- deparse(x_name)
+  }
 
   if (!length(x)) {
     return(x)
@@ -153,7 +230,9 @@ check_all_elements_class_character <- function(x, x_name = substitute(x)) {
 }
 
 check_all_elements_unique <- function(x, x_name = substitute(x)) {
-  if (is.name(x)) x_name <- deparse(x_name)
+  if (is.name(x)) {
+    x_name <- deparse(x_name)
+  }
 
   if (!length(x)) {
     return(x)
@@ -166,7 +245,9 @@ check_all_elements_unique <- function(x, x_name = substitute(x)) {
 }
 
 check_no_sf <- function(data, data_name = substitute(data)) {
-  if (!is.character(data_name)) data_name <- deparse(data_name)
+  if (!is.character(data_name)) {
+    data_name <- deparse(data_name)
+  }
 
   if (inherits(data, "sf")) {
     err(data_name, " must not be an sf object.", tidy = FALSE)

--- a/R/coef-profile.R
+++ b/R/coef-profile.R
@@ -10,15 +10,21 @@ coef_profile <- function(object, ...) {
 }
 
 #' @export
-coef_profile.mb_null_analysis <- function(object, param_type = "fixed", include_constant = TRUE,
-                                          conf_level = getOption("mb.conf_level", 0.95),
-                                          estimate = getOption("mb.estimate", median),
-                                          parallel = getOption("mb.parallel", FALSE),
-                                          beep = getOption("mb.beep", TRUE),
-                                          simplify = TRUE,
-                                          ...) {
+coef_profile.mb_null_analysis <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  parallel = getOption("mb.parallel", FALSE),
+  beep = getOption("mb.beep", TRUE),
+  simplify = TRUE,
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
 
   coef(
     object,
@@ -48,30 +54,42 @@ coef_profile.mb_null_analysis <- function(object, param_type = "fixed", include_
 #' @param ... Not used.
 #' @return A tidy tibble of the coefficient terms.
 #' @export
-coef_profile.mb_analysis <- function(object, param_type = "fixed", include_constant = TRUE,
-                                     conf_level = getOption("mb.conf_level", 0.95),
-                                     estimate = getOption("mb.estimate", median),
-                                     parallel = getOption("mb.parallel", FALSE),
-                                     beep = getOption("mb.profile", TRUE),
-                                     simplify = TRUE,
-                                     ...) {
+coef_profile.mb_analysis <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  parallel = getOption("mb.parallel", FALSE),
+  beep = getOption("mb.profile", TRUE),
+  simplify = TRUE,
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
   beep <- FALSE
 
-  coef <- coef(object,
+  coef <- coef(
+    object,
     param_type = param_type,
     include_constant = include_constant,
-    conf_level = conf_level, estimate = estimate,
-    simplify = simplify, ...
+    conf_level = conf_level,
+    estimate = estimate,
+    simplify = simplify,
+    ...
   )
 
   if (is_bayesian(object)) {
     warning("coef_profile is undefined for Bayesian models - returning coef")
   } else {
-    confint <- confint(object,
-      parm = coef$term, conf_level = conf_level,
-      beep = FALSE, parallel = parallel,
+    confint <- confint(
+      object,
+      parm = coef$term,
+      conf_level = conf_level,
+      beep = FALSE,
+      parallel = parallel,
       simplify = simplify
     )
     stopifnot(identical(confint$term, coef$term))
@@ -97,15 +115,19 @@ coef_profile.mb_analysis <- function(object, param_type = "fixed", include_const
 #' Akaike's weight and the proportion of models including the term.
 #' @export
 coef_profile.mb_analyses <- function(
-    object, param_type = "fixed",
-    include_constant = TRUE,
-    conf_level = getOption("mb.conf_level", 0.95),
-    estimate = getOption("mb.estimate", median),
-    parallel = getOption("mb.parallel", FALSE),
-    beep = getOption("mb.beep", TRUE),
-    ...) {
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  parallel = getOption("mb.parallel", FALSE),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
   beep <- FALSE
 
   ic <- IC(object)
@@ -133,7 +155,8 @@ coef_profile.mb_analyses <- function(
       coef <- dplyr::mutate(coef, sd = `!!`(parse_expr("numeric(0)")))
       coef <- get_frequentist_coef(coef)
     }
-    coef <- dplyr::mutate(coef,
+    coef <- dplyr::mutate(
+      coef,
       nmodels = integer(0),
       proportion = numeric(0),
       ICWt = numeric(0)
@@ -142,20 +165,33 @@ coef_profile.mb_analyses <- function(
     return(coef)
   }
 
-  suppressWarnings(coef <- purrr::map2_df(coef, ic$model, function(x, y) {
-    x$model <- y
-    x
-  }))
+  suppressWarnings(
+    coef <- purrr::map2_df(coef, ic$model, function(x, y) {
+      x$model <- y
+      x
+    })
+  )
 
   coef <- dplyr::mutate(coef, .IN = `!!`(parse_expr("1")))
-  coef <- tidyr::complete(coef, `!!`(parse_expr("term")), `!!`(parse_expr("model")), fill = list(estimate = 0, sd = 0, .IN = 0))
-  coef <- dplyr::inner_join(coef, dplyr::select(ic, `!!`(parse_expr("model")), `!!`(parse_expr("ICWt"))), by = "model")
-  coef <- dplyr::mutate(coef,
+  coef <- tidyr::complete(
+    coef,
+    `!!`(parse_expr("term")),
+    `!!`(parse_expr("model")),
+    fill = list(estimate = 0, sd = 0, .IN = 0)
+  )
+  coef <- dplyr::inner_join(
+    coef,
+    dplyr::select(ic, `!!`(parse_expr("model")), `!!`(parse_expr("ICWt"))),
+    by = "model"
+  )
+  coef <- dplyr::mutate(
+    coef,
     coef = `!!`(parse_expr("estimate")),
     var = `!!`(parse_expr("pow(sd,2)"))
   )
   coef <- dplyr::group_by(coef, `!!`(parse_expr("term")))
-  coef <- dplyr::summarise(coef,
+  coef <- dplyr::summarise(
+    coef,
     estimate = `!!`(parse_expr("sum(ICWt * estimate)")),
     sd = `!!`(parse_expr("sqrt(sum(ICWt * (var + pow(coef - estimate, 2))))")),
     nmodels = `!!`(parse_expr("nmodels")),
@@ -170,7 +206,8 @@ coef_profile.mb_analyses <- function(
 
   coef <- get_frequentist_coef(coef)
   coef <- dplyr::select(
-    coef, `!!`(parse_expr("term")),
+    coef,
+    `!!`(parse_expr("term")),
     `!!`(parse_expr("estimate")),
     `!!`(parse_expr("sd")),
     `!!`(parse_expr("zscore")),
@@ -197,14 +234,20 @@ coef_profile.mb_analyses <- function(
 #' @param ... Not used.
 #' @return A tidy tibble.
 #' @export
-coef_profile.mb_meta_analysis <- function(object, param_type = "fixed", include_constant = TRUE,
-                                          conf_level = getOption("mb.conf_level", 0.95),
-                                          estimate = getOption("mb.estimate", median),
-                                          parallel = getOption("mb.parallel", FALSE),
-                                          beep = getOption("mb.beep", TRUE),
-                                          ...) {
+coef_profile.mb_meta_analysis <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  parallel = getOption("mb.parallel", FALSE),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
   beep <- FALSE
 
   lapply(
@@ -232,14 +275,20 @@ coef_profile.mb_meta_analysis <- function(object, param_type = "fixed", include_
 #' @param ... Not used.
 #' @return A tidy tibble.
 #' @export
-coef_profile.mb_meta_analyses <- function(object, param_type = "fixed", include_constant = TRUE,
-                                          conf_level = getOption("mb.conf_level", 0.95),
-                                          estimate = getOption("mb.estimate", median),
-                                          parallel = getOption("mb.parallel", FALSE),
-                                          beep = getOption("mb.parallel", TRUE),
-                                          ...) {
+coef_profile.mb_meta_analyses <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  parallel = getOption("mb.parallel", FALSE),
+  beep = getOption("mb.parallel", TRUE),
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
   beep <- FALSE
 
   lapply(

--- a/R/coef.R
+++ b/R/coef.R
@@ -1,7 +1,10 @@
 #' @export
 stats::coef
 
-warn_default_directional_information <- function(env = parent.frame(), user_env = parent.frame(2)) {
+warn_default_directional_information <- function(
+  env = parent.frame(),
+  user_env = parent.frame(2)
+) {
   lifecycle::deprecate_soft(
     "1.1.0",
     "coef(directional_information = 'should be explicitly set')",
@@ -15,22 +18,28 @@ warn_default_directional_information <- function(env = parent.frame(), user_env 
 }
 
 get_frequentist_coef <- function(object, conf_level = 0.95) {
-  object <- dplyr::mutate(object,
+  object <- dplyr::mutate(
+    object,
     zscore = .data$estimate / .data$sd,
     lower = .data$estimate + .data$sd * qnorm((1 - conf_level) / 2),
-    upper = .data$estimate + .data$sd * qnorm((1 - conf_level) / 2 + conf_level),
+    upper = .data$estimate +
+      .data$sd * qnorm((1 - conf_level) / 2 + conf_level),
     pvalue = 2 * pnorm(-abs(.data$zscore))
   )
   object
 }
 
 #' @export
-coef.mb_null_analysis <- function(object, param_type = "fixed", include_constant = TRUE,
-                                  conf_level = getOption("mb.conf_level", 0.95),
-                                  estimate = getOption("mb.estimate", median),
-                                  simplify = FALSE,
-                                  directional_information = FALSE,
-                                  ...) {
+coef.mb_null_analysis <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  simplify = FALSE,
+  directional_information = FALSE,
+  ...
+) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
   chk_flag(include_constant)
@@ -41,7 +50,8 @@ coef.mb_null_analysis <- function(object, param_type = "fixed", include_constant
 
   coef <- tibble(
     term = as_term(character(0)),
-    estimate = numeric(0), sd = numeric(0),
+    estimate = numeric(0),
+    sd = numeric(0),
     zscore = numeric(0)
   )
 
@@ -50,7 +60,11 @@ coef.mb_null_analysis <- function(object, param_type = "fixed", include_constant
   if (simplify) {
     coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
     coef <- select(
-      coef, "term", "estimate", "lower", "upper",
+      coef,
+      "term",
+      "estimate",
+      "lower",
+      "upper",
       "svalue"
     )
   }
@@ -81,12 +95,16 @@ coef.mb_null_analysis <- function(object, param_type = "fixed", include_constant
 #' @param ... Not used.
 #' @return A tidy tibble of the coefficient terms.
 #' @export
-coef.mb_analysis <- function(object, param_type = "fixed", include_constant = TRUE,
-                             conf_level = getOption("mb.conf_level", 0.95),
-                             estimate = getOption("mb.estimate", median),
-                             simplify = FALSE,
-                             directional_information = FALSE,
-                             ...) {
+coef.mb_analysis <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  simplify = FALSE,
+  directional_information = FALSE,
+  ...
+) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
   chk_flag(include_constant)
@@ -113,7 +131,11 @@ coef.mb_analysis <- function(object, param_type = "fixed", include_constant = TR
     if (simplify) {
       coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
       coef <- select(
-        coef, "term", "estimate", "lower", "upper",
+        coef,
+        "term",
+        "estimate",
+        "lower",
+        "upper",
         "svalue"
       )
     }
@@ -125,12 +147,16 @@ coef.mb_analysis <- function(object, param_type = "fixed", include_constant = TR
   if (is_bayesian(object)) {
     coef <- as.mcmcr(object)
     coef <- subset(coef, pars = pars)
-    coef <- coef(coef,
-      estimate = estimate, simplify = simplify,
+    coef <- coef(
+      coef,
+      estimate = estimate,
+      simplify = simplify,
       directional_information = directional_information
     )
 
-    if (!include_constant) coef <- dplyr::filter(coef, .data$lower != .data$upper)
+    if (!include_constant) {
+      coef <- dplyr::filter(coef, .data$lower != .data$upper)
+    }
   } else {
     coef <- as.mcmcr(object)
     coef <- subset(coef, pars = pars)
@@ -143,11 +169,17 @@ coef.mb_analysis <- function(object, param_type = "fixed", include_constant = TR
     coef$sd <- sd$estimate
 
     coef <- get_frequentist_coef(coef, conf_level = conf_level)
-    if (!include_constant) coef <- dplyr::filter(coef, .data$lower != .data$upper)
+    if (!include_constant) {
+      coef <- dplyr::filter(coef, .data$lower != .data$upper)
+    }
     if (simplify) {
       coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
       coef <- select(
-        coef, "term", "estimate", "lower", "upper",
+        coef,
+        "term",
+        "estimate",
+        "lower",
+        "upper",
         "svalue"
       )
     }
@@ -171,10 +203,14 @@ coef.mb_analysis <- function(object, param_type = "fixed", include_constant = TR
 #' @return A tidy tibble of the coeffcient terms with the model averaged estimate, the
 #' Akaike's weight and the proportion of models including the term.
 #' @export
-coef.mb_analyses <- function(object, param_type = "fixed", include_constant = TRUE,
-                             conf_level = getOption("mb.conf_level", 0.95),
-                             estimate = getOption("mb.estimate", median),
-                             ...) {
+coef.mb_analyses <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  ...
+) {
   ic <- IC(object)
   coef <- lapply(
     object,
@@ -198,7 +234,8 @@ coef.mb_analyses <- function(object, param_type = "fixed", include_constant = TR
       coef <- dplyr::mutate(coef, sd = `!!`(parse_expr("numeric(0)")))
       coef <- get_frequentist_coef(coef)
     }
-    coef <- dplyr::mutate(coef,
+    coef <- dplyr::mutate(
+      coef,
       nmodels = integer(0),
       proportion = numeric(0),
       ICWt = numeric(0)
@@ -207,20 +244,33 @@ coef.mb_analyses <- function(object, param_type = "fixed", include_constant = TR
     return(coef)
   }
 
-  suppressWarnings(coef <- purrr::map2_df(coef, ic$model, function(x, y) {
-    x$model <- y
-    x
-  }))
+  suppressWarnings(
+    coef <- purrr::map2_df(coef, ic$model, function(x, y) {
+      x$model <- y
+      x
+    })
+  )
 
   coef <- dplyr::mutate(coef, .IN = `!!`(parse_expr("1")))
-  coef <- tidyr::complete(coef, `!!`(parse_expr("term")), `!!`(parse_expr("model")), fill = list(estimate = 0, sd = 0, .IN = 0))
-  coef <- dplyr::inner_join(coef, dplyr::select(ic, `!!`(parse_expr("model")), `!!`(parse_expr("ICWt"))), by = "model")
-  coef <- dplyr::mutate(coef,
+  coef <- tidyr::complete(
+    coef,
+    `!!`(parse_expr("term")),
+    `!!`(parse_expr("model")),
+    fill = list(estimate = 0, sd = 0, .IN = 0)
+  )
+  coef <- dplyr::inner_join(
+    coef,
+    dplyr::select(ic, `!!`(parse_expr("model")), `!!`(parse_expr("ICWt"))),
+    by = "model"
+  )
+  coef <- dplyr::mutate(
+    coef,
     coef = `!!`(parse_expr("estimate")),
     var = `!!`(parse_expr("pow(sd,2)"))
   )
   coef <- dplyr::group_by(coef, `!!`(parse_expr("term")))
-  coef <- dplyr::summarise(coef,
+  coef <- dplyr::summarise(
+    coef,
     estimate = `!!`(parse_expr("sum(ICWt * estimate)")),
     sd = `!!`(parse_expr("sqrt(sum(ICWt * (var + pow(coef - estimate, 2))))")),
     nmodels = `!!`(parse_expr("nmodels")),
@@ -235,7 +285,8 @@ coef.mb_analyses <- function(object, param_type = "fixed", include_constant = TR
 
   coef <- get_frequentist_coef(coef)
   coef <- dplyr::select(
-    coef, `!!`(parse_expr("term")),
+    coef,
+    `!!`(parse_expr("term")),
     `!!`(parse_expr("estimate")),
     `!!`(parse_expr("sd")),
     `!!`(parse_expr("zscore")),
@@ -260,10 +311,14 @@ coef.mb_analyses <- function(object, param_type = "fixed", include_constant = TR
 #' @param ... Not used.
 #' @return A tidy tibble.
 #' @export
-coef.mb_meta_analysis <- function(object, param_type = "fixed", include_constant = TRUE,
-                                  conf_level = getOption("mb.conf_level", 0.95),
-                                  estimate = getOption("mb.estimate", median),
-                                  ...) {
+coef.mb_meta_analysis <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  ...
+) {
   lapply(
     object,
     coef,
@@ -285,10 +340,14 @@ coef.mb_meta_analysis <- function(object, param_type = "fixed", include_constant
 #' @param ... Not used.
 #' @return A tidy tibble.
 #' @export
-coef.mb_meta_analyses <- function(object, param_type = "fixed", include_constant = TRUE,
-                                  conf_level = getOption("mb.conf_level", 0.95),
-                                  estimate = getOption("mb.estimate", median),
-                                  ...) {
+coef.mb_meta_analyses <- function(
+  object,
+  param_type = "fixed",
+  include_constant = TRUE,
+  conf_level = getOption("mb.conf_level", 0.95),
+  estimate = getOption("mb.estimate", median),
+  ...
+) {
   lapply(
     object,
     coef,

--- a/R/comments.R
+++ b/R/comments.R
@@ -34,7 +34,10 @@ rm_comments.character <- function(object, comment_string = "#", ...) {
 
 #' @export
 rm_comments.mb_code <- function(object, ...) {
-  object$template <- rm_comments(object$template, comment_string = comment_string(object))
+  object$template <- rm_comments(
+    object$template,
+    comment_string = comment_string(object)
+  )
   object
 }
 

--- a/R/data-set.R
+++ b/R/data-set.R
@@ -9,14 +9,24 @@
 #' @param ... Unused.
 #' @return The data set as a tibble.
 #' @export
-data_set <- function(x, modify = FALSE, numericize_factors = FALSE,
-                     marginalize_random_effects = FALSE, ...) {
+data_set <- function(
+  x,
+  modify = FALSE,
+  numericize_factors = FALSE,
+  marginalize_random_effects = FALSE,
+  ...
+) {
   UseMethod("data_set")
 }
 
 #' @export
-data_set.mb_analysis <- function(x, modify = FALSE, numericize_factors = FALSE,
-                                 marginalize_random_effects = FALSE, ...) {
+data_set.mb_analysis <- function(
+  x,
+  modify = FALSE,
+  numericize_factors = FALSE,
+  marginalize_random_effects = FALSE,
+  ...
+) {
   chk_flag(modify)
   chk_flag(numericize_factors)
   chk_flag(marginalize_random_effects)
@@ -40,28 +50,51 @@ data_set.mb_analysis <- function(x, modify = FALSE, numericize_factors = FALSE,
 }
 
 #' @export
-data_set.mb_analyses <- function(x, modify = FALSE, numericize_factors = FALSE,
-                                 marginalize_random_effects = FALSE, ...) {
-  data_set(x[[1]],
-    modify = modify, numericize_factors = numericize_factors,
+data_set.mb_analyses <- function(
+  x,
+  modify = FALSE,
+  numericize_factors = FALSE,
+  marginalize_random_effects = FALSE,
+  ...
+) {
+  data_set(
+    x[[1]],
+    modify = modify,
+    numericize_factors = numericize_factors,
     marginalize_random_effects = marginalize_random_effects
   )
 }
 
 #' @export
-data_set.mb_meta_analysis <- function(x, modify = FALSE, numericize_factors = FALSE,
-                                      marginalize_random_effects = FALSE, ...) {
-  lapply(x, data_set,
-    modify = modify, numericize_factors = numericize_factors,
+data_set.mb_meta_analysis <- function(
+  x,
+  modify = FALSE,
+  numericize_factors = FALSE,
+  marginalize_random_effects = FALSE,
+  ...
+) {
+  lapply(
+    x,
+    data_set,
+    modify = modify,
+    numericize_factors = numericize_factors,
     marginalize_random_effects = marginalize_random_effects
   )
 }
 
 #' @export
-data_set.mb_meta_analyses <- function(x, modify = FALSE, numericize_factors = FALSE,
-                                      marginalize_random_effects = FALSE, ...) {
-  lapply(x, data_set,
-    modify = modify, numericize_factors = numericize_factors,
+data_set.mb_meta_analyses <- function(
+  x,
+  modify = FALSE,
+  numericize_factors = FALSE,
+  marginalize_random_effects = FALSE,
+  ...
+) {
+  lapply(
+    x,
+    data_set,
+    modify = modify,
+    numericize_factors = numericize_factors,
     marginalize_random_effects = marginalize_random_effects
   )
 }

--- a/R/derive.R
+++ b/R/derive.R
@@ -39,19 +39,21 @@
 #'   coef()
 #' }
 #' @export
-mcmc_derive.mb_analysis <- function(object,
-                                    new_data = data_set(object),
-                                    new_expr = NULL,
-                                    new_values = list(),
-                                    term = "prediction",
-                                    modify_new_data = NULL,
-                                    ref_data = FALSE,
-                                    ref_fun2 = proportional_change2,
-                                    random_effects = NULL,
-                                    new_expr_vec = getOption("mb.new_expr_vec", FALSE),
-                                    parallel = getOption("mb.parallel", FALSE),
-                                    quiet = getOption("mb.quiet", TRUE),
-                                    ...) {
+mcmc_derive.mb_analysis <- function(
+  object,
+  new_data = data_set(object),
+  new_expr = NULL,
+  new_values = list(),
+  term = "prediction",
+  modify_new_data = NULL,
+  ref_data = FALSE,
+  ref_fun2 = proportional_change2,
+  random_effects = NULL,
+  new_expr_vec = getOption("mb.new_expr_vec", FALSE),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  ...
+) {
   chk_function(ref_fun2)
 
   if (!vld_data(new_data) && !vld_character(new_data)) {
@@ -119,20 +121,24 @@ mcmc_derive.mb_analysis <- function(object,
 
 #' @rdname mcmc_derive.mb_analysis
 #' @export
-mcmc_derive.mb_analyses <- function(object,
-                                    new_data = data_set(object),
-                                    new_expr = NULL,
-                                    new_values = list(),
-                                    term = "prediction",
-                                    modify_new_data = NULL,
-                                    ref_data = FALSE,
-                                    new_expr_vec = getOption("mb.new_expr_vec", FALSE),
-                                    parallel = getOption("mb.parallel", FALSE),
-                                    quiet = getOption("mb.quiet", TRUE),
-                                    ...) {
+mcmc_derive.mb_analyses <- function(
+  object,
+  new_data = data_set(object),
+  new_expr = NULL,
+  new_values = list(),
+  term = "prediction",
+  modify_new_data = NULL,
+  ref_data = FALSE,
+  new_expr_vec = getOption("mb.new_expr_vec", FALSE),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  ...
+) {
   ic <- IC(object)
 
-  if (!all(is.finite(ic$IC))) err("non-finite IC values", tidy = FALSE)
+  if (!all(is.finite(ic$IC))) {
+    err("non-finite IC values", tidy = FALSE)
+  }
 
   object <- lapply(
     object,
@@ -149,7 +155,9 @@ mcmc_derive.mb_analyses <- function(object,
     beep = FALSE
   )
 
-  set_weight <- function(x, weight) mcmc_map(x, .f = function(x, weight) x * weight, weight = weight)
+  set_weight <- function(x, weight) {
+    mcmc_map(x, .f = function(x, weight) x * weight, weight = weight)
+  }
 
   object <- purrr::map2(object, ic$ICWt, set_weight)
 

--- a/R/drop-parameters.R
+++ b/R/drop-parameters.R
@@ -17,13 +17,14 @@ drop_pars.character <- function(x, pars = character(0), ...) {
   chk_not_any_na(pars)
   chk_unique(pars)
 
-
   if (!length(pars)) {
     return(x)
   }
 
   # check that [ not in parameter name or followed by [ in x
-  if (any(grepl("\\[", pars))) err("pars must be scalar", tidy = FALSE)
+  if (any(grepl("\\[", pars))) {
+    err("pars must be scalar", tidy = FALSE)
+  }
   if (length(x) & length(pars)) {
     if (length(x) && any(stringr::str_detect(x, p0(pars, "\\s*\\[")))) {
       err("pars must be scalar", tidy = FALSE)
@@ -53,10 +54,13 @@ drop_pars_language <- function(expr, pars = character(0), ...) {
   }
 
   # check that [ not in parameter name or followed by [ in x
-  if (any(grepl("\\[", pars))) err("pars must be scalar", tidy = FALSE)
+  if (any(grepl("\\[", pars))) {
+    err("pars must be scalar", tidy = FALSE)
+  }
 
   walk_ast <- function(x) {
-    switch_expr(x,
+    switch_expr(
+      x,
       # Base cases
       constant = x,
       symbol = {
@@ -92,7 +96,6 @@ drop_pars.mb_model <- function(x, pars = character(0), ...) {
   chk_s3_class(pars, "character")
   chk_not_any_na(pars)
   chk_unique(pars)
-
 
   if (!length(pars)) {
     return(x)

--- a/R/drops.R
+++ b/R/drops.R
@@ -90,9 +90,13 @@ next_drop <- function(analysis, drops, conf_level) {
   # scalar only
   coef <- dplyr::filter(coef, !grepl("\\[", .data$term))
 
-  if (!all(drop %in% coef$term)) err("unrecognised fixed scalar parameter", tidy = FALSE)
+  if (!all(drop %in% coef$term)) {
+    err("unrecognised fixed scalar parameter", tidy = FALSE)
+  }
 
-  if (any(is.na(coef$pvalue))) err("undefined pvalues", tidy = FALSE)
+  if (any(is.na(coef$pvalue))) {
+    err("undefined pvalues", tidy = FALSE)
+  }
 
   coef <- dplyr::filter(coef, .data$pvalue > (1 - .data$conf_level))
   if (!nrow(coef)) {

--- a/R/glance.R
+++ b/R/glance.R
@@ -2,7 +2,12 @@
 generics::glance
 
 #' @export
-glance.mb_analysis <- function(x, rhat = getOption("mb.rhat", 1.1), esr = getOption("mb.esr", 0.33), ...) {
+glance.mb_analysis <- function(
+  x,
+  rhat = getOption("mb.rhat", 1.1),
+  esr = getOption("mb.esr", 0.33),
+  ...
+) {
   glance <- tibble(
     n = sample_size(x),
     K = nterms(x, include_constant = FALSE)
@@ -22,11 +27,18 @@ glance.mb_analysis <- function(x, rhat = getOption("mb.rhat", 1.1), esr = getOpt
 
 #' @export
 glance.mb_analyses <- function(
-    x, rhat = getOption("mb.rhat", 1.1), bound = FALSE, ...) {
+  x,
+  rhat = getOption("mb.rhat", 1.1),
+  bound = FALSE,
+  ...
+) {
   chk_flag(bound)
   if (bound) {
     if (!is_bayesian(x)) {
-      err("glance with bound = TRUE is only defined for Bayesian analyses.", tidy = FALSE)
+      err(
+        "glance with bound = TRUE is only defined for Bayesian analyses.",
+        tidy = FALSE
+      )
     }
 
     glance <- glance(x, rhat = rhat)

--- a/R/log-lik-draws.R
+++ b/R/log-lik-draws.R
@@ -16,7 +16,12 @@ priorsense::log_lik_draws
 #' @returns A draws_array object containing log_lik values.
 #' @export
 #'
-log_lik_draws.mb_analysis <- function(x, joint = FALSE, log_lik_name = "log_lik", ...) {
+log_lik_draws.mb_analysis <- function(
+  x,
+  joint = FALSE,
+  log_lik_name = "log_lik",
+  ...
+) {
   if (!is.mb_analysis(x)) {
     stop("Not an mb_analysis object.", call. = FALSE)
   }
@@ -25,15 +30,24 @@ log_lik_draws.mb_analysis <- function(x, joint = FALSE, log_lik_name = "log_lik"
   chk::chk_character(log_lik_name)
   chk::chk_unused(...)
 
-  def_new_expr <- any(stringr::str_detect(as.character(x$model$new_expr), paste0("\\b", log_lik_name, "\\b")))
+  def_new_expr <- any(stringr::str_detect(
+    as.character(x$model$new_expr),
+    paste0("\\b", log_lik_name, "\\b")
+  ))
   def_model <- any(stringr::str_detect(pars(x), log_lik_name))
 
   if (def_new_expr & def_model) {
-    warning("`log_lik` is defined as a parameter within the model and in the new expression; the definition in the new expression will take precedence.")
+    warning(
+      "`log_lik` is defined as a parameter within the model and in the new expression; the definition in the new expression will take precedence."
+    )
   }
 
   if (def_new_expr) {
-    log_lik <- posterior::as_draws_array(as.mcmc.list(mcmc_derive(x, term = log_lik_name, parallel = FALSE)))
+    log_lik <- posterior::as_draws_array(as.mcmc.list(mcmc_derive(
+      x,
+      term = log_lik_name,
+      parallel = FALSE
+    )))
   } else if (def_model) {
     log_lik <- posterior::subset_draws(
       posterior::as_draws_array(as.mcmc.list(x$mcmcr)),

--- a/R/log-prior-draws.R
+++ b/R/log-prior-draws.R
@@ -16,7 +16,12 @@ priorsense::log_prior_draws
 #' @return A draws_array object containing log_prior values.
 #' @export
 #'
-log_prior_draws.mb_analysis <- function(x, joint = FALSE, log_prior_name = "lprior", ...) {
+log_prior_draws.mb_analysis <- function(
+  x,
+  joint = FALSE,
+  log_prior_name = "lprior",
+  ...
+) {
   if (!is.mb_analysis(x)) {
     stop("Not an mb_analysis object.", call. = FALSE)
   }
@@ -25,15 +30,24 @@ log_prior_draws.mb_analysis <- function(x, joint = FALSE, log_prior_name = "lpri
   chk::chk_character(log_prior_name)
   chk::chk_unused(...)
 
-  def_new_expr <- any(stringr::str_detect(as.character(x$model$new_expr), log_prior_name))
+  def_new_expr <- any(stringr::str_detect(
+    as.character(x$model$new_expr),
+    log_prior_name
+  ))
   def_model <- any(stringr::str_detect(pars(x), log_prior_name))
 
   if (def_new_expr & def_model) {
-    warning("`lprior` is defined both as a parameter within the model and in the new expression. Change `lprior` in the new expression to `elprior`, and supply `log_prior_name = 'elprior'` to the function.")
+    warning(
+      "`lprior` is defined both as a parameter within the model and in the new expression. Change `lprior` in the new expression to `elprior`, and supply `log_prior_name = 'elprior'` to the function."
+    )
   }
 
   if (def_new_expr) {
-    log_prior <- posterior::as_draws_array(as.mcmc.list(mcmc_derive(x, term = log_prior_name, parallel = FALSE)))
+    log_prior <- posterior::as_draws_array(as.mcmc.list(mcmc_derive(
+      x,
+      term = log_prior_name,
+      parallel = FALSE
+    )))
   } else if (def_model) {
     log_prior <- posterior::subset_draws(
       posterior::as_draws_array(as.mcmc.list(x$mcmcr)),

--- a/R/make-all-models.R
+++ b/R/make-all-models.R
@@ -8,7 +8,9 @@ make_all_models <- function(model, drops = list()) {
   check_mb_model(model)
   check_drops(drops)
 
-  if (!length(drops)) drops <- model$drops
+  if (!length(drops)) {
+    drops <- model$drops
+  }
 
   if (!length(drops)) {
     return(models(full = model))

--- a/R/mcmcr.R
+++ b/R/mcmcr.R
@@ -1,6 +1,11 @@
 #' @export
-rhat.mb_analysis <- function(x, by = "all", param_type = "all", as_df = FALSE,
-                             ...) {
+rhat.mb_analysis <- function(
+  x,
+  by = "all",
+  param_type = "all",
+  as_df = FALSE,
+  ...
+) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
   chk_unused(...)
@@ -16,8 +21,14 @@ rhat.mb_analysis <- function(x, by = "all", param_type = "all", as_df = FALSE,
 rhat.mb_null_analysis <- function(x, ...) Inf
 
 #' @export
-rhat.mb_analyses <- function(x, by = "all", param_type = "all", as_df = FALSE,
-                             bound = FALSE, ...) {
+rhat.mb_analyses <- function(
+  x,
+  by = "all",
+  param_type = "all",
+  as_df = FALSE,
+  bound = FALSE,
+  ...
+) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
   chk_unused(...)
@@ -31,7 +42,13 @@ rhat.mb_analyses <- function(x, by = "all", param_type = "all", as_df = FALSE,
 }
 
 #' @export
-esr.mb_analysis <- function(x, by = "all", as_df = FALSE, param_type = "all", ...) {
+esr.mb_analysis <- function(
+  x,
+  by = "all",
+  as_df = FALSE,
+  param_type = "all",
+  ...
+) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
   chk_unused(...)
@@ -47,7 +64,13 @@ esr.mb_analysis <- function(x, by = "all", as_df = FALSE, param_type = "all", ..
 esr.mb_null_analysis <- function(x, ...) 0
 
 #' @export
-esr.mb_analyses <- function(x, by = "all", as_df = FALSE, param_type = "all", ...) {
+esr.mb_analyses <- function(
+  x,
+  by = "all",
+  as_df = FALSE,
+  param_type = "all",
+  ...
+) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
   chk_unused(...)
@@ -61,8 +84,15 @@ esr.mb_analyses <- function(x, by = "all", as_df = FALSE, param_type = "all", ..
 }
 
 #' @export
-converged.mb_analysis <- function(x, rhat = 1.1, esr = 0.33, by = "all",
-                                  param_type = "all", as_df = FALSE, ...) {
+converged.mb_analysis <- function(
+  x,
+  rhat = 1.1,
+  esr = 0.33,
+  by = "all",
+  param_type = "all",
+  as_df = FALSE,
+  ...
+) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
   chk_unused(...)
@@ -79,10 +109,16 @@ converged.mb_analysis <- function(x, rhat = 1.1, esr = 0.33, by = "all",
 converged.mb_null_analysis <- function(x, ...) FALSE
 
 #' @export
-converged.mb_analyses <- function(x, rhat = 1.1, esr = 0.33, by = "all",
-                                  param_type = "all", as_df = FALSE,
-                                  bound = FALSE,
-                                  ...) {
+converged.mb_analyses <- function(
+  x,
+  rhat = 1.1,
+  esr = 0.33,
+  by = "all",
+  param_type = "all",
+  as_df = FALSE,
+  bound = FALSE,
+  ...
+) {
   chk_string(param_type)
   chk_subset(param_type, c("fixed", "random", "derived", "primary", "all"))
   chk_unused(...)

--- a/R/modify-data.R
+++ b/R/modify-data.R
@@ -49,13 +49,37 @@ select_rescale_data <- function(data, model, data2 = data) {
   chk_data(data2)
   chk_not_empty(data2)
   check_mb_model(model)
-  data <- select_data(data, model$select_data, model$center, model$scale, model$random_effects)
-  data2 <- select_data(data2, model$select_data, model$center, model$scale, model$random_effects)
+  data <- select_data(
+    data,
+    model$select_data,
+    model$center,
+    model$scale,
+    model$random_effects
+  )
+  data2 <- select_data(
+    data2,
+    model$select_data,
+    model$center,
+    model$scale,
+    model$random_effects
+  )
 
-  if (!identical(model$center, character(0)) || !identical(model$scale, character(0))) {
-    data <- rescale::rescale(data, data2 = data2, center = model$center, scale = model$scale)
+  if (
+    !identical(model$center, character(0)) ||
+      !identical(model$scale, character(0))
+  ) {
+    data <- rescale::rescale(
+      data,
+      data2 = data2,
+      center = model$center,
+      scale = model$scale
+    )
   } else if (length(model$select_data)) {
-    data <- rescale::rescale_c(data, data2 = data2, colnames = names(model$select_data))
+    data <- rescale::rescale_c(
+      data,
+      data2 = data2,
+      colnames = names(model$select_data)
+    )
   }
   data
 }
@@ -86,7 +110,9 @@ modify_data <- function(data, model, numericize_factors = FALSE) {
   data <- numericize_dates(data)
   data <- numericize_difftimes(data)
   data <- add_nfactors(data)
-  if (numericize_factors) data <- numericize_factors(data)
+  if (numericize_factors) {
+    data <- numericize_factors(data)
+  }
   data$nObs <- nobs
   data <- model$modify_data(data)
   data
@@ -102,7 +128,13 @@ modify_data <- function(data, model, numericize_factors = FALSE) {
 #' @param modify_new_data A single argument function to modify new data (in list form) immediately prior to calculating new_expr.
 #' @return The modified data in list form.
 #' @export
-modify_new_data <- function(data, data2, model, modify_new_data = NULL, numericize_factors = FALSE) {
+modify_new_data <- function(
+  data,
+  data2,
+  model,
+  modify_new_data = NULL,
+  numericize_factors = FALSE
+) {
   chk_data(data)
   chk_not_empty(data)
   chk_data(data2)
@@ -110,7 +142,9 @@ modify_new_data <- function(data, data2, model, modify_new_data = NULL, numerici
   check_mb_model(model)
   chk_flag(numericize_factors)
 
-  if (is.null(modify_new_data)) modify_new_data <- model$modify_new_data
+  if (is.null(modify_new_data)) {
+    modify_new_data <- model$modify_new_data
+  }
   check_single_arg_fun(modify_new_data)
 
   if (any(c("nObs", "Obs") %in% colnames(data))) {
@@ -126,7 +160,9 @@ modify_new_data <- function(data, data2, model, modify_new_data = NULL, numerici
   data <- numericize_difftimes(data)
   data <- add_nfactors(data)
 
-  if (numericize_factors) data <- numericize_factors(data)
+  if (numericize_factors) {
+    data <- numericize_factors(data)
+  }
   data$nObs <- nobs
   data <- modify_new_data(data)
   data

--- a/R/monitor.R
+++ b/R/monitor.R
@@ -5,7 +5,9 @@
 #' @return A character vector of the pars to monitor.
 #' @export
 monitor <- function(object, param_type = "all") {
-  if (!is.mb_model(object)) err("object must be an mb_model", tidy = FALSE)
+  if (!is.mb_model(object)) {
+    err("object must be an mb_model", tidy = FALSE)
+  }
 
   pars <- pars(object, param_type = param_type)
 

--- a/R/new-expr.R
+++ b/R/new-expr.R
@@ -104,7 +104,14 @@ enexpr_new_expr <- function(new_expr, default = NULL, vectorize = FALSE) {
   if (is.character(new_expr)) {
     # FIXME: Add compatibility warning?
     try_new_expr <- try(parse_expr(new_expr), silent = TRUE)
-    if (inherits(try_new_expr, "try-error") && stringr::str_detect(try_new_expr, "must contain exactly 1 expression") && vld_string(new_expr)) {
+    if (
+      inherits(try_new_expr, "try-error") &&
+        stringr::str_detect(
+          try_new_expr,
+          "must contain exactly 1 expression"
+        ) &&
+        vld_string(new_expr)
+    ) {
       new_expr <- paste0("{\n", new_expr, "\n}")
     }
     new_expr <- parse_expr(new_expr)

--- a/R/numericize.R
+++ b/R/numericize.R
@@ -3,7 +3,9 @@ days_since_2000 <- function(x) {
 }
 
 numericize_dates <- function(data) {
-  if (!is.list(data)) err("data must be a list", tidy = FALSE)
+  if (!is.list(data)) {
+    err("data must be a list", tidy = FALSE)
+  }
   if (!length(data)) {
     return(data)
   }
@@ -15,7 +17,9 @@ numericize_dates <- function(data) {
 }
 
 numericize_difftimes <- function(data) {
-  if (!is.list(data)) err("data must be a list", tidy = FALSE)
+  if (!is.list(data)) {
+    err("data must be a list", tidy = FALSE)
+  }
   if (!length(data)) {
     return(data)
   }
@@ -27,7 +31,9 @@ numericize_difftimes <- function(data) {
 }
 
 numericize_logicals <- function(data) {
-  if (!is.list(data)) err("data must be a list", tidy = FALSE)
+  if (!is.list(data)) {
+    err("data must be a list", tidy = FALSE)
+  }
   if (!length(data)) {
     return(data)
   }
@@ -39,7 +45,9 @@ numericize_logicals <- function(data) {
 }
 
 numericize_factors <- function(data) {
-  if (!is.list(data)) err("data must be a list", tidy = FALSE)
+  if (!is.list(data)) {
+    err("data must be a list", tidy = FALSE)
+  }
   if (!length(data)) {
     return(data)
   }

--- a/R/pars.R
+++ b/R/pars.R
@@ -24,17 +24,21 @@ pars.mb_code <- function(x, ...) {
 #' @export
 pars.mb_model <- function(x, param_type = "all", ...) {
   chk_string(param_type)
-  chk_subset(param_type, c("fixed", "random", "derived", "primary", "all", "raw"))
+  chk_subset(
+    param_type,
+    c("fixed", "random", "derived", "primary", "all", "raw")
+  )
   chk_unused(...)
 
   if (param_type == "raw") {
     return(pars(code(x)))
   }
 
-
   if (param_type %in% c("primary", "all")) {
     pars <- c("fixed", "random")
-    if (param_type == "all") pars <- c(pars, "derived")
+    if (param_type == "all") {
+      pars <- c(pars, "derived")
+    }
 
     pars <- purrr::map(pars, pars_arg2to1, x = x)
     pars <- unlist(pars)
@@ -44,7 +48,9 @@ pars.mb_model <- function(x, param_type = "all", ...) {
   }
 
   random <- names(random_effects(x))
-  if (is.null(random)) random <- character(0)
+  if (is.null(random)) {
+    random <- character(0)
+  }
   random <- sort(random)
 
   if (param_type == "random") {
@@ -74,8 +80,13 @@ pars.mb_model <- function(x, param_type = "all", ...) {
 #' @export
 pars.mb_analysis <- function(x, param_type = "all", scalar = NULL, ...) {
   chk_string(param_type)
-  chk_subset(param_type, c("fixed", "random", "derived", "primary", "all", "raw"))
-  if (!is.null(scalar)) chk_flag(scalar)
+  chk_subset(
+    param_type,
+    c("fixed", "random", "derived", "primary", "all", "raw")
+  )
+  if (!is.null(scalar)) {
+    chk_flag(scalar)
+  }
 
   if (param_type == "raw") {
     return(pars(get_model(x), param_type = "raw"))
@@ -83,7 +94,9 @@ pars.mb_analysis <- function(x, param_type = "all", scalar = NULL, ...) {
 
   if (param_type %in% c("primary", "all")) {
     pars <- c("fixed", "random")
-    if (param_type == "all") pars <- c(pars, "derived")
+    if (param_type == "all") {
+      pars <- c(pars, "derived")
+    }
 
     pars <- purrr::map(pars, pars_arg2to1, x = x, scalar = scalar)
     pars <- unlist(pars)
@@ -95,7 +108,9 @@ pars.mb_analysis <- function(x, param_type = "all", scalar = NULL, ...) {
   pars <- pars(as.mcmcr(x), scalar = scalar)
 
   random <- names(random_effects(x))
-  if (is.null(random)) random <- character(0)
+  if (is.null(random)) {
+    random <- character(0)
+  }
   random <- intersect(random, pars)
   random <- sort(random)
 

--- a/R/plot-data.R
+++ b/R/plot-data.R
@@ -36,7 +36,9 @@ plot_data.default <- function(x, y, x_name, y_name, ...) {
 #' @export
 plot_data.factor <- function(x, y, x_name, y_name, ...) {
   ggplot_data(x, y, x_name, y_name) +
-    ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust = 1))
+    ggplot2::theme(
+      axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust = 1)
+    )
 }
 
 #' @export
@@ -54,8 +56,10 @@ plot_data.data.frame <- function(x, ...) {
     for (y_name in names(x)) {
       if (!identical(x_name, y_name)) {
         plot <- plot_data(
-          x = x[[x_name]], y = x[[y_name]],
-          x_name = x_name, y_name = y_name
+          x = x[[x_name]],
+          y = x[[y_name]],
+          x_name = x_name,
+          y_name = y_name
         )
         plot <- list(plot)
         plot <- stats::setNames(plot, paste(x_name, y_name))

--- a/R/pmb-analyse.R
+++ b/R/pmb-analyse.R
@@ -1,9 +1,10 @@
 #' @export
 analyse.pmb_model <- function(
-    x,
-    data,
-    ...,
-    engine = NULL) {
+  x,
+  data,
+  ...,
+  engine = NULL
+) {
   # FIXME: Generic translation
   if (identical(engine, "jags")) {
     x$code <- translate_jmbr(x$code)

--- a/R/pmbr-check-pmbr.R
+++ b/R/pmbr-check-pmbr.R
@@ -2,41 +2,47 @@
 sd_dists <- c("dnorm", "dlnorm", "dt")
 
 check_pmbr <- function(expr) {
-  switch(expr_type(expr),
-    call = {
-      if (as.character(expr[[1]]) %in% sd_dists) {
-        if (names2(as.list(expr))[[3]] != "sd") {
-          err("`", as.character(expr[[1]]), "()` must be used with a named argument `sd`")
-        }
-        if (is.call(expr[[3]])) {
-          if (expr[[3]][[1]] == "^") {
-            if (expr[[3]][[3]][[1]] == "-" && expr[[3]][[3]][[2]] == 2) {
-              err(
-                "The `sd` argument to `",
-                as.character(expr[[1]]),
-                "()` must be a standard deviation, not a term like `... ^ -2`"
-              )
-            }
-            if (expr[[3]][[3]][[1]] == "(" && expr[[3]][[3]][[2]][[1]] == "-" && expr[[3]][[3]][[2]][[2]] == 2) {
-              err(
-                "The `sd` argument to `",
-                as.character(expr[[1]]),
-                "()` must be a standard deviation, not a term like `... ^ (-2)`"
-              )
-            }
-          }
-          if (expr[[3]][[1]] == "/" && expr[[3]][[2]] == 1) {
+  switch(expr_type(expr), call = {
+    if (as.character(expr[[1]]) %in% sd_dists) {
+      if (names2(as.list(expr))[[3]] != "sd") {
+        err(
+          "`",
+          as.character(expr[[1]]),
+          "()` must be used with a named argument `sd`"
+        )
+      }
+      if (is.call(expr[[3]])) {
+        if (expr[[3]][[1]] == "^") {
+          if (expr[[3]][[3]][[1]] == "-" && expr[[3]][[3]][[2]] == 2) {
             err(
               "The `sd` argument to `",
               as.character(expr[[1]]),
-              "()` must be a standard deviation, not a term like `1 / ...`"
+              "()` must be a standard deviation, not a term like `... ^ -2`"
+            )
+          }
+          if (
+            expr[[3]][[3]][[1]] == "(" &&
+              expr[[3]][[3]][[2]][[1]] == "-" &&
+              expr[[3]][[3]][[2]][[2]] == 2
+          ) {
+            err(
+              "The `sd` argument to `",
+              as.character(expr[[1]]),
+              "()` must be a standard deviation, not a term like `... ^ (-2)`"
             )
           }
         }
+        if (expr[[3]][[1]] == "/" && expr[[3]][[2]] == 1) {
+          err(
+            "The `sd` argument to `",
+            as.character(expr[[1]]),
+            "()` must be a standard deviation, not a term like `1 / ...`"
+          )
+        }
       }
-      walk(as.list(expr)[-1], check_pmbr)
     }
-  )
+    walk(as.list(expr)[-1], check_pmbr)
+  })
 }
 
 expr_type <- function(x) {

--- a/R/pmbr-translate-jmbr.R
+++ b/R/pmbr-translate-jmbr.R
@@ -4,16 +4,37 @@ translate_jmbr <- function(template) {
   mb_code(out)
 }
 
-r_ops <- c("+", "-", "*", "/", "^", "%%", "%/%", ">", "<", ">=", "<=", "==", "!=", "&", "|", "!", ":", "~", "=", "<-")
+r_ops <- c(
+  "+",
+  "-",
+  "*",
+  "/",
+  "^",
+  "%%",
+  "%/%",
+  ">",
+  "<",
+  ">=",
+  "<=",
+  "==",
+  "!=",
+  "&",
+  "|",
+  "!",
+  ":",
+  "~",
+  "=",
+  "<-"
+)
 r_brackets <- c("(" = ")", "{" = "}", "[" = "]")
 
 # ";"
 
 walk_translate_jmbr <- function(expr) {
-  switch(expr_type(expr),
+  switch(
+    expr_type(expr),
     constant = ,
-    symbol =
-      as.character(expr),
+    symbol = as.character(expr),
     call = {
       if (as.character(expr[[1]]) %in% c("T", "I")) {
         t_fun <- expr[[1]]
@@ -35,7 +56,11 @@ walk_translate_jmbr <- function(expr) {
           }
 
           if (fun == "{") {
-            paste0("{\n", paste(gsub("(^|\n)", "\\1  ", args), collapse = "\n"), "\n}")
+            paste0(
+              "{\n",
+              paste(gsub("(^|\n)", "\\1  ", args), collapse = "\n"),
+              "\n}"
+            )
           } else if (fun == "[") {
             paste0(args[[1]], "[", paste0(args[-1], collapse = ", "), "]")
           } else if (fun == "(") {

--- a/R/posterior-predictive-check.R
+++ b/R/posterior-predictive-check.R
@@ -31,8 +31,18 @@ posterior_predictive_check.mb_analysis <- function(x, zeros = TRUE, ...) {
   simulate_residuals <- as.mcmc(collapse_chains(simulate_residuals$mcmc))
 
   means <- apply(simulate_residuals, 1, FUN = extras::xtr_mean, na_rm = TRUE)
-  variances <- apply(simulate_residuals, 1, FUN = extras::variance, na_rm = TRUE)
-  skewnesses <- apply(simulate_residuals, 1, FUN = extras::skewness, na_rm = TRUE)
+  variances <- apply(
+    simulate_residuals,
+    1,
+    FUN = extras::variance,
+    na_rm = TRUE
+  )
+  skewnesses <- apply(
+    simulate_residuals,
+    1,
+    FUN = extras::skewness,
+    na_rm = TRUE
+  )
   kurtoses <- apply(simulate_residuals, 1, FUN = extras::kurtosis, na_rm = TRUE)
 
   residuals <- residuals$estimate
@@ -58,12 +68,32 @@ posterior_predictive_check.mb_analysis <- function(x, zeros = TRUE, ...) {
     zeroses_svalue <- NA_real_
   }
 
-  tibble <- tibble::tibble(moment = c("zeros", "mean", "variance", "skewness", "kurtosis"))
+  tibble <- tibble::tibble(
+    moment = c("zeros", "mean", "variance", "skewness", "kurtosis")
+  )
   tibble$moment <- factor(tibble$moment, tibble$moment)
   tibble$observed <- c(zeros, mean, variance, skewness, kurtosis)
-  tibble$median <- c(median(zeroses), median(means), median(variances), median(skewnesses), median(kurtoses))
-  tibble$lower <- c(lower(zeroses), lower(means), lower(variances), lower(skewnesses), lower(kurtoses))
-  tibble$upper <- c(upper(zeroses), upper(means), upper(variances), upper(skewnesses), upper(kurtoses))
+  tibble$median <- c(
+    median(zeroses),
+    median(means),
+    median(variances),
+    median(skewnesses),
+    median(kurtoses)
+  )
+  tibble$lower <- c(
+    lower(zeroses),
+    lower(means),
+    lower(variances),
+    lower(skewnesses),
+    lower(kurtoses)
+  )
+  tibble$upper <- c(
+    upper(zeroses),
+    upper(means),
+    upper(variances),
+    upper(skewnesses),
+    upper(kurtoses)
+  )
   tibble$svalue <- c(
     zeroses_svalue,
     svalue(means, threshold = mean),

--- a/R/reanalyse.R
+++ b/R/reanalyse.R
@@ -23,21 +23,61 @@ reanalyse1 <- function(object, parallel, quiet, ...) {
   UseMethod("reanalyse1")
 }
 
-reanalyse_model <- function(object, name = NULL, rhat, esr, nreanalyses, duration, parallel, quiet, glance, beep, ...) {
-  if (!is.null(name) & glance) cat("Model:", name, "\n")
-  reanalyse(object,
-    rhat = rhat, esr = esr, nreanalyses = nreanalyses,
-    duration = duration, quiet = quiet,
-    glance = glance, beep = beep, ...
+reanalyse_model <- function(
+  object,
+  name = NULL,
+  rhat,
+  esr,
+  nreanalyses,
+  duration,
+  parallel,
+  quiet,
+  glance,
+  beep,
+  ...
+) {
+  if (!is.null(name) & glance) {
+    cat("Model:", name, "\n")
+  }
+  reanalyse(
+    object,
+    rhat = rhat,
+    esr = esr,
+    nreanalyses = nreanalyses,
+    duration = duration,
+    quiet = quiet,
+    glance = glance,
+    beep = beep,
+    ...
   )
 }
 
-reanalyse_data <- function(object, name = NULL, rhat, esr, nreanalyses, duration, parallel, quiet, glance, beep, ...) {
-  if (!is.null(name) & glance) cat("Data:", name, "\n")
-  reanalyse(object,
-    rhat = rhat, esr = esr, nreanalyses = nreanalyses,
-    duration = duration, quiet = quiet,
-    glance = glance, beep = beep, ...
+reanalyse_data <- function(
+  object,
+  name = NULL,
+  rhat,
+  esr,
+  nreanalyses,
+  duration,
+  parallel,
+  quiet,
+  glance,
+  beep,
+  ...
+) {
+  if (!is.null(name) & glance) {
+    cat("Data:", name, "\n")
+  }
+  reanalyse(
+    object,
+    rhat = rhat,
+    esr = esr,
+    nreanalyses = nreanalyses,
+    duration = duration,
+    quiet = quiet,
+    glance = glance,
+    beep = beep,
+    ...
   )
 }
 
@@ -54,38 +94,59 @@ reanalyse_data <- function(object, name = NULL, rhat, esr, nreanalyses, duration
 #' @param parallel A flag indicating whether to perform the analysis in parallel if possible.
 #' @param ... Unused arguments.
 #' @export
-reanalyse.mb_analysis <- function(object,
-                                  rhat = getOption("mb.rhat", 1.1),
-                                  esr = getOption("mb.esr", 0.33),
-                                  nreanalyses = getOption("mb.nreanalyses", 1L),
-                                  duration = getOption("mb.duration", dhours(1)),
-                                  parallel = getOption("mb.parallel", FALSE),
-                                  quiet = getOption("mb.quiet", TRUE),
-                                  glance = getOption("mb.glance", TRUE),
-                                  beep = getOption("mb.beep", TRUE),
-                                  ...) {
+reanalyse.mb_analysis <- function(
+  object,
+  rhat = getOption("mb.rhat", 1.1),
+  esr = getOption("mb.esr", 0.33),
+  nreanalyses = getOption("mb.nreanalyses", 1L),
+  duration = getOption("mb.duration", dhours(1)),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   chk_flag(beep)
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
 
   chk_whole_number(nreanalyses)
   chk_range(nreanalyses, c(0L, 4L))
-  if (!is.duration(duration)) err("duration must be an object of class Duration", tidy = FALSE)
+  if (!is.duration(duration)) {
+    err("duration must be an object of class Duration", tidy = FALSE)
+  }
   chk_flag(quiet)
   chk_flag(parallel)
   chk_flag(glance)
   chk_number(esr)
   chk_range(esr, c(0, 1))
 
-  if (nreanalyses == 0L || duration < elapsed(object) * 2 || converged(object, rhat = rhat, esr = esr)) {
-    if (glance) print(glance(object))
+  if (
+    nreanalyses == 0L ||
+      duration < elapsed(object) * 2 ||
+      converged(object, rhat = rhat, esr = esr)
+  ) {
+    if (glance) {
+      print(glance(object))
+    }
     return(object)
   }
-  while (nreanalyses > 0L && duration >= elapsed(object) * 2 && !converged(object, rhat = rhat, esr = esr)) {
-    object <- analyse(model(object), data_set(object),
-      nchains = nchains(object), niters = niters(object),
+  while (
+    nreanalyses > 0L &&
+      duration >= elapsed(object) * 2 &&
+      !converged(object, rhat = rhat, esr = esr)
+  ) {
+    object <- analyse(
+      model(object),
+      data_set(object),
+      nchains = nchains(object),
+      niters = niters(object),
       nthin = nthin(object) * 2L,
-      parallel = parallel, quiet = quiet,
-      glance = glance, beep = FALSE
+      parallel = parallel,
+      quiet = quiet,
+      glance = glance,
+      beep = FALSE
     )
     nreanalyses <- nreanalyses - 1L
   }
@@ -105,19 +166,23 @@ reanalyse.mb_analysis <- function(object,
 #' @param parallel A flag indicating whether to perform the analysis in parallel if possible
 #' @param ... Unused arguments.
 #' @export
-reanalyse.mb_analyses <- function(object,
-                                  rhat = getOption("mb.rhat", 1.1),
-                                  esr = getOption("mb.esr", 0.33),
-                                  nreanalyses = getOption("mb.nreanalyses", 1L),
-                                  duration = getOption("mb.duration", dhours(1)),
-                                  parallel = getOption("mb.parallel", FALSE),
-                                  quiet = getOption("mb.quiet", TRUE),
-                                  glance = getOption("mb.glance", TRUE),
-                                  beep = getOption("mb.beep", TRUE),
-                                  ...) {
+reanalyse.mb_analyses <- function(
+  object,
+  rhat = getOption("mb.rhat", 1.1),
+  esr = getOption("mb.esr", 0.33),
+  nreanalyses = getOption("mb.nreanalyses", 1L),
+  duration = getOption("mb.duration", dhours(1)),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   chk_flag(beep)
 
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
 
   if (!length(object)) {
     return(object)
@@ -128,10 +193,17 @@ reanalyse.mb_analyses <- function(object,
     names(object) <- 1:length(object)
   }
 
-  object <- purrr::imap(object, reanalyse_model,
-    rhat = rhat, esr = esr,
-    nreanalyses = nreanalyses, duration = duration,
-    quiet = quiet, glance = glance, beep = FALSE, ...
+  object <- purrr::imap(
+    object,
+    reanalyse_model,
+    rhat = rhat,
+    esr = esr,
+    nreanalyses = nreanalyses,
+    duration = duration,
+    quiet = quiet,
+    glance = glance,
+    beep = FALSE,
+    ...
   )
 
   object <- as_mb_analyses(object, names)
@@ -151,19 +223,23 @@ reanalyse.mb_analyses <- function(object,
 #' @param parallel A flag indicating whether to perform the analysis in parallel if possible
 #' @param ... Unused arguments.
 #' @export
-reanalyse.mb_meta_analysis <- function(object,
-                                       rhat = getOption("mb.rhat", 1.1),
-                                       esr = getOption("mb.esr", 0.33),
-                                       nreanalyses = getOption("mb.nreanalyses", 1L),
-                                       duration = getOption("mb.duration", dhours(1)),
-                                       parallel = getOption("mb.parallel", FALSE),
-                                       quiet = getOption("mb.quiet", TRUE),
-                                       glance = getOption("mb.glance", TRUE),
-                                       beep = getOption("mb.beep", TRUE),
-                                       ...) {
+reanalyse.mb_meta_analysis <- function(
+  object,
+  rhat = getOption("mb.rhat", 1.1),
+  esr = getOption("mb.esr", 0.33),
+  nreanalyses = getOption("mb.nreanalyses", 1L),
+  duration = getOption("mb.duration", dhours(1)),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   chk_flag(beep)
 
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
 
   if (!length(object)) {
     return(object)
@@ -174,10 +250,17 @@ reanalyse.mb_meta_analysis <- function(object,
     names(object) <- 1:length(object)
   }
 
-  object <- purrr::imap(object, reanalyse_data,
-    rhat = rhat, esr = esr,
-    nreanalyses = nreanalyses, duration = duration,
-    quiet = quiet, glance = glance, beep = FALSE, ...
+  object <- purrr::imap(
+    object,
+    reanalyse_data,
+    rhat = rhat,
+    esr = esr,
+    nreanalyses = nreanalyses,
+    duration = duration,
+    quiet = quiet,
+    glance = glance,
+    beep = FALSE,
+    ...
   )
 
   object <- as_mb_meta_analysis(object, names)
@@ -197,19 +280,23 @@ reanalyse.mb_meta_analysis <- function(object,
 #' @param parallel A flag indicating whether to perform the analysis in parallel if possible
 #' @param ... Unused arguments.
 #' @export
-reanalyse.mb_meta_analyses <- function(object,
-                                       rhat = getOption("mb.rhat", 1.1),
-                                       esr = getOption("mb.esr", 0.33),
-                                       nreanalyses = getOption("mb.nreanalyses", 1L),
-                                       duration = getOption("mb.duration", dhours(1)),
-                                       parallel = getOption("mb.parallel", FALSE),
-                                       quiet = getOption("mb.quiet", TRUE),
-                                       glance = getOption("mb.glance", TRUE),
-                                       beep = getOption("mb.beep", TRUE),
-                                       ...) {
+reanalyse.mb_meta_analyses <- function(
+  object,
+  rhat = getOption("mb.rhat", 1.1),
+  esr = getOption("mb.esr", 0.33),
+  nreanalyses = getOption("mb.nreanalyses", 1L),
+  duration = getOption("mb.duration", dhours(1)),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   chk_flag(beep)
 
-  if (beep) on.exit(beepr::beep())
+  if (beep) {
+    on.exit(beepr::beep())
+  }
 
   if (!length(object)) {
     return(object)
@@ -223,10 +310,17 @@ reanalyse.mb_meta_analyses <- function(object,
   object <- purrr::transpose(object)
   object <- lapply(object, as_mb_meta_analysis)
 
-  object <- purrr::imap(object, reanalyse_model,
-    rhat = rhat, esr = esr,
-    nreanalyses = nreanalyses, duration = duration,
-    quiet = quiet, glance = glance, beep = FALSE, ...
+  object <- purrr::imap(
+    object,
+    reanalyse_model,
+    rhat = rhat,
+    esr = esr,
+    nreanalyses = nreanalyses,
+    duration = duration,
+    quiet = quiet,
+    glance = glance,
+    beep = FALSE,
+    ...
   )
 
   object <- purrr::transpose(object)

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -70,7 +70,9 @@ plot_residuals.factor <- function(x, name, residuals, ...) {
 
   gp <- ggplot_residuals(data, name) +
     ggplot2::geom_jitter(alpha = 1 / 3, width = 0.20) +
-    ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust = 1))
+    ggplot2::theme(
+      axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust = 1)
+    )
   gp
 }
 
@@ -83,8 +85,13 @@ plot_residuals.mb_analysis <- function(x, ...) {
   residuals <- residuals(x)
   fit <- fitted(x)
   variables <- dplyr::select_(
-    residuals, ~ -estimate, ~ -sd, ~ -zscore,
-    ~ -lower, ~ -upper, ~ -pvalue
+    residuals,
+    ~ -estimate,
+    ~ -sd,
+    ~ -zscore,
+    ~ -lower,
+    ~ -upper,
+    ~ -pvalue
   )
   variables$fit <- fit$estimate
 
@@ -94,7 +101,12 @@ plot_residuals.mb_analysis <- function(x, ...) {
   variables <- purrr::discard(variables, is.character)
   variables <- purrr::keep(variables, is_multiple_values)
 
-  plots <- purrr::map2(variables, names(variables), plot_residuals, residuals = residuals)
+  plots <- purrr::map2(
+    variables,
+    names(variables),
+    plot_residuals,
+    residuals = residuals
+  )
   plots <- purrr::discard(plots, is.null)
   plots
 }

--- a/R/sd-priors-by.R
+++ b/R/sd-priors-by.R
@@ -8,13 +8,23 @@
 #' @param ... Not used.
 #' @return The updated object.
 #' @export
-sd_priors_by <- function(x, by = 10, distributions = c("normal", "lognormal", "t"), ...) {
+sd_priors_by <- function(
+  x,
+  by = 10,
+  distributions = c("normal", "lognormal", "t"),
+  ...
+) {
   UseMethod("sd_priors_by")
 }
 
 #' @describeIn sd_priors_by Multiply Standard Deviation of Priors for an MB model
 #' @export
-sd_priors_by.mb_model <- function(x, by = 10, distributions = c("normal", "lognormal", "t"), ...) {
+sd_priors_by.mb_model <- function(
+  x,
+  by = 10,
+  distributions = c("normal", "lognormal", "t"),
+  ...
+) {
   chk_number(by)
   chk_range(by, c(0.001, 1000))
   chk_unused(...)
@@ -25,20 +35,27 @@ sd_priors_by.mb_model <- function(x, by = 10, distributions = c("normal", "logno
 
 #' @describeIn sd_priors_by Multiply Standard Deviation of Priors for an MB analysis
 #' @export
-sd_priors_by.mb_analysis <- function(x, by = 10, distributions = c("normal", "lognormal", "t"),
-                                     parallel = getOption("mb.parallel", FALSE),
-                                     quiet = getOption("mb.quiet", TRUE),
-                                     glance = getOption("mb.glance", TRUE),
-                                     beep = getOption("mb.beep", TRUE),
-                                     ...) {
+sd_priors_by.mb_analysis <- function(
+  x,
+  by = 10,
+  distributions = c("normal", "lognormal", "t"),
+  parallel = getOption("mb.parallel", FALSE),
+  quiet = getOption("mb.quiet", TRUE),
+  glance = getOption("mb.glance", TRUE),
+  beep = getOption("mb.beep", TRUE),
+  ...
+) {
   chk_unused(...)
 
-  analyse(sd_priors_by(model(x), by = by, distributions = distributions),
+  analyse(
+    sd_priors_by(model(x), by = by, distributions = distributions),
     data = data_set(x),
     nchains = nchains(x),
     niters = niters(x),
     nthin = nthin(x),
     parallel = parallel,
-    quiet = quiet, glance = glance, beep = beep
+    quiet = quiet,
+    glance = glance,
+    beep = beep
   )
 }

--- a/R/sensitivity.R
+++ b/R/sensitivity.R
@@ -5,25 +5,34 @@
 #'   or "all".
 #' @param param_type A string specifying which parameters to include: 'fixed',
 #'   'random', 'derived', 'primary', or 'all'.
-#' @param mb.prior_cjs A number specifying the CJS threshold for weak prior 
+#' @param mb.prior_cjs A number specifying the CJS threshold for weak prior
 #'   classification.
-#' @param mb.lik_cjs A number specifying the CJS threshold for strong data 
+#' @param mb.lik_cjs A number specifying the CJS threshold for strong data
 #'   classification.
 #' @param ... Arguments passed to [add_sensitivity()].
 #'
 #' @return A tibble summarizing the sensitivity of the analysis object.
 #' @export
-sensitivity <- function(x, by = "term", param_type = "all",
-                        mb.prior_cjs = getOption("mb.prior_cjs", 0.1),
-                        mb.lik_cjs = getOption("mb.lik_cjs", 0.05), ...) {
+sensitivity <- function(
+  x,
+  by = "term",
+  param_type = "all",
+  mb.prior_cjs = getOption("mb.prior_cjs", 0.1),
+  mb.lik_cjs = getOption("mb.lik_cjs", 0.05),
+  ...
+) {
   UseMethod("sensitivity")
 }
 
 #' @export
-sensitivity.mb_analysis <- function(x, by = "term", param_type = "all",
-                                    mb.prior_cjs = getOption("mb.prior_cjs", 0.1),
-                                    mb.lik_cjs = getOption("mb.lik_cjs", 0.05),
-                                    ...) {
+sensitivity.mb_analysis <- function(
+  x,
+  by = "term",
+  param_type = "all",
+  mb.prior_cjs = getOption("mb.prior_cjs", 0.1),
+  mb.lik_cjs = getOption("mb.lik_cjs", 0.05),
+  ...
+) {
   check_mb_analysis(x)
   chk_string(by)
   chk_subset(by, c("all", "parameter", "term"))
@@ -43,7 +52,10 @@ sensitivity.mb_analysis <- function(x, by = "term", param_type = "all",
     dplyr::mutate(parameter = term::pars_terms(.data$term)) |>
     dplyr::filter(!is.nan(.data$prior)) |>
     dplyr::select(
-      "parameter", "term", "prior", "likelihood"
+      "parameter",
+      "term",
+      "prior",
+      "likelihood"
     ) |>
     dplyr::mutate(
       dplyr::across(c("prior", "likelihood"), \(x) round(x, 3)),
@@ -68,8 +80,12 @@ sensitivity.mb_analysis <- function(x, by = "term", param_type = "all",
         .groups = "drop"
       ) |>
       dplyr::select(
-        "parameter", "nterms", "prior", "likelihood",
-        "weak_prior", "strong_data"
+        "parameter",
+        "nterms",
+        "prior",
+        "likelihood",
+        "weak_prior",
+        "strong_data"
       ) |>
       dplyr::arrange(.data$parameter, .data$weak_prior, .data$strong_data)
   } else if (by == "all") {
@@ -83,7 +99,11 @@ sensitivity.mb_analysis <- function(x, by = "term", param_type = "all",
         .groups = "drop"
       ) |>
       dplyr::select(
-        "nterms", "prior", "likelihood", "weak_prior", "strong_data"
+        "nterms",
+        "prior",
+        "likelihood",
+        "weak_prior",
+        "strong_data"
       ) |>
       dplyr::arrange(.data$weak_prior, .data$strong_data)
   }

--- a/R/set-analysis-mode.R
+++ b/R/set-analysis-mode.R
@@ -129,6 +129,11 @@ set_analysis_mode <- function(mode = "report") {
       mb.conf_level = 0.95
     )
   } else {
-    err("mode '", mode, "' unrecognised (possible values are 'debug', 'reset', 'check', 'quick', 'report' or 'paper')", tidy = FALSE)
+    err(
+      "mode '",
+      mode,
+      "' unrecognised (possible values are 'debug', 'reset', 'check', 'quick', 'report' or 'paper')",
+      tidy = FALSE
+    )
   }
 }

--- a/R/simulate-residuals.R
+++ b/R/simulate-residuals.R
@@ -14,7 +14,8 @@ expr_type <- function(x) {
 }
 
 switch_expr <- function(x, ...) {
-  switch(expr_type(x),
+  switch(
+    expr_type(x),
     ...,
     stop("Don't know how to handle type ", typeof(x), call. = FALSE)
   )
@@ -36,7 +37,8 @@ edit_residuals_code <- function(new_expr, type = NULL, simulate = NULL) {
   }
 
   is_res_call <- function(xx) {
-    is.call(xx) && grepl("^res_[[:alnum:]_]+$", rlang::as_string(xx[[1]]), perl = TRUE)
+    is.call(xx) &&
+      grepl("^res_[[:alnum:]_]+$", rlang::as_string(xx[[1]]), perl = TRUE)
   }
 
   tweak_res_call <- function(xx) {
@@ -79,7 +81,9 @@ edit_residuals_code <- function(new_expr, type = NULL, simulate = NULL) {
   new_expr <- walk_ast(new_expr)
 
   if (!residual_assignment_found) {
-    err("`new_expr` must include `residual <- res_xxx(` or `residual[i] <- res_xxx(`.")
+    err(
+      "`new_expr` must include `residual <- res_xxx(` or `residual[i] <- res_xxx(`."
+    )
   }
 
   new_expr

--- a/R/terms.R
+++ b/R/terms.R
@@ -8,7 +8,12 @@ stats::terms
 #' @param include_constant A flag specifying whether to include constant terms.
 #' @param ... unused
 #' @export
-nterms.mb_analysis <- function(x, param_type = "fixed", include_constant = TRUE, ...) {
+nterms.mb_analysis <- function(
+  x,
+  param_type = "fixed",
+  include_constant = TRUE,
+  ...
+) {
   length(terms(x, param_type = param_type, include_constant = include_constant))
 }
 
@@ -21,9 +26,17 @@ nterms.mb_analysis <- function(x, param_type = "fixed", include_constant = TRUE,
 #' @param include_constant A flag specifying whether to include constant terms.
 #' @param ... Not used.
 #' @export
-terms.mb_analysis <- function(x, param_type = "fixed", include_constant = TRUE, ...) {
-  coef(x,
-    param_type = param_type, include_constant = include_constant,
-    simplify = TRUE, directional_information = FALSE
+terms.mb_analysis <- function(
+  x,
+  param_type = "fixed",
+  include_constant = TRUE,
+  ...
+) {
+  coef(
+    x,
+    param_type = param_type,
+    include_constant = include_constant,
+    simplify = TRUE,
+    directional_information = FALSE
   )$term
 }

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -2,9 +2,16 @@
 generics::tidy
 
 #' @export
-tidy.mb_analysis <- function(x, conf_level = getOption("mb.conf_level", 0.95), ...) {
-  coef <- coef(x,
-    conf_level = conf_level, beep = FALSE, simplify = TRUE,
+tidy.mb_analysis <- function(
+  x,
+  conf_level = getOption("mb.conf_level", 0.95),
+  ...
+) {
+  coef <- coef(
+    x,
+    conf_level = conf_level,
+    beep = FALSE,
+    simplify = TRUE,
     directional_information = FALSE
   )
 

--- a/R/update-model.R
+++ b/R/update-model.R
@@ -8,57 +8,89 @@
 #' @return An object inheriting from class mb_model.
 #' @export
 update_model <- function(
-    model,
-    code = NULL,
-    gen_inits = NULL,
-    random_effects = NULL,
-    fixed = NULL,
-    derived = NULL,
-    select_data = NULL,
-    center = NULL,
-    scale = NULL,
-    modify_data = NULL,
-    nthin = NULL,
-    new_expr = NULL,
-    new_expr_vec = NULL,
-    modify_new_data = NULL,
-    drops = NULL,
-    ...) {
+  model,
+  code = NULL,
+  gen_inits = NULL,
+  random_effects = NULL,
+  fixed = NULL,
+  derived = NULL,
+  select_data = NULL,
+  center = NULL,
+  scale = NULL,
+  modify_data = NULL,
+  nthin = NULL,
+  new_expr = NULL,
+  new_expr_vec = NULL,
+  modify_new_data = NULL,
+  drops = NULL,
+  ...
+) {
   UseMethod("update_model")
 }
 
 #' @export
 update_model.mb_model <- function(
-    model,
-    code = NULL,
-    gen_inits = NULL,
-    random_effects = NULL,
-    fixed = NULL,
-    derived = NULL,
-    select_data = NULL,
-    center = NULL,
-    scale = NULL,
-    modify_data = NULL,
-    nthin = NULL,
-    new_expr = NULL,
-    new_expr_vec = NULL,
-    modify_new_data = NULL,
-    drops = NULL,
-    ...) {
-  if (is.null(code)) code <- code(model)
-  if (is.null(gen_inits)) gen_inits <- model$gen_inits
-  if (is.null(random_effects)) random_effects <- model$random_effects
-  if (is.null(fixed)) fixed <- model$fixed
-  if (is.null(derived)) derived <- model$derived
-  if (is.null(select_data)) select_data <- model$select_data
-  if (is.null(center)) center <- model$center
-  if (is.null(scale)) scale <- model$scale
-  if (is.null(modify_data)) modify_data <- model$modify_data
-  if (is.null(nthin)) nthin <- model$nthin
-  if (is.null(new_expr_vec)) new_expr_vec <- model$new_expr_vec
-  new_expr <- enexpr_new_expr({{ new_expr }}, default = model$new_expr, vectorize = new_expr_vec)
-  if (is.null(modify_new_data)) modify_new_data <- model$modify_new_data
-  if (is.null(drops)) drops <- model$drops
+  model,
+  code = NULL,
+  gen_inits = NULL,
+  random_effects = NULL,
+  fixed = NULL,
+  derived = NULL,
+  select_data = NULL,
+  center = NULL,
+  scale = NULL,
+  modify_data = NULL,
+  nthin = NULL,
+  new_expr = NULL,
+  new_expr_vec = NULL,
+  modify_new_data = NULL,
+  drops = NULL,
+  ...
+) {
+  if (is.null(code)) {
+    code <- code(model)
+  }
+  if (is.null(gen_inits)) {
+    gen_inits <- model$gen_inits
+  }
+  if (is.null(random_effects)) {
+    random_effects <- model$random_effects
+  }
+  if (is.null(fixed)) {
+    fixed <- model$fixed
+  }
+  if (is.null(derived)) {
+    derived <- model$derived
+  }
+  if (is.null(select_data)) {
+    select_data <- model$select_data
+  }
+  if (is.null(center)) {
+    center <- model$center
+  }
+  if (is.null(scale)) {
+    scale <- model$scale
+  }
+  if (is.null(modify_data)) {
+    modify_data <- model$modify_data
+  }
+  if (is.null(nthin)) {
+    nthin <- model$nthin
+  }
+  if (is.null(new_expr_vec)) {
+    new_expr_vec <- model$new_expr_vec
+  }
+  new_expr <- enexpr_new_expr(
+    {{ new_expr }},
+    default = model$new_expr,
+    vectorize = new_expr_vec
+  )
+  if (is.null(modify_new_data)) {
+    modify_new_data <- model$modify_new_data
+  }
+  if (is.null(drops)) {
+    drops <- model$drops
+  }
 
   inject(model(
     x = code,

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,8 +19,20 @@ pars_arg2to1 <- function(param_type, x, scalar = NULL) {
   pars(x = x, param_type = param_type, scalar = scalar)
 }
 
-coef_arg2to1 <- function(param_type, object, include_constant, conf_level, ...) {
-  coef(object, param_type = param_type, include_constant = include_constant, conf_level = conf_level, ...)
+coef_arg2to1 <- function(
+  param_type,
+  object,
+  include_constant,
+  conf_level,
+  ...
+) {
+  coef(
+    object,
+    param_type = param_type,
+    include_constant = include_constant,
+    conf_level = conf_level,
+    ...
+  )
 }
 
 
@@ -162,7 +174,9 @@ drop_indices <- function(x) {
 }
 
 response_lm <- function(x) {
-  if (!is.character(x)) x <- template(x)
+  if (!is.character(x)) {
+    x <- template(x)
+  }
   x <- sub("\\s+~.*", "", x)
   x <- gsub("\\s{1,}", "", x)
   x

--- a/R/zero.R
+++ b/R/zero.R
@@ -7,7 +7,12 @@ zero_random_effects <- function(mcmcr, data, random_effects) {
   data <- data[vapply(data, all1, TRUE)]
   data <- names(data)
 
-  random_effects <- vapply(random_effects, function(x, y) any(x %in% y), TRUE, data)
+  random_effects <- vapply(
+    random_effects,
+    function(x, y) any(x %in% y),
+    TRUE,
+    data
+  )
   random_effects <- random_effects[random_effects]
   random_effects <- names(random_effects)
 

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/data-raw/density99.R
+++ b/data-raw/density99.R
@@ -25,7 +25,8 @@ site_year <- expand.grid(Site = site$Site, Year = 1:nyear + start_year)
 site_year$site_year_effect <- rnorm(nrow(site_year), sd = exp(log_sd_site_year))
 
 data <- expand.grid(
-  Visit = 1:nvisit, Site = site$Site,
+  Visit = 1:nvisit,
+  Site = site$Site,
   Year = 1:nyear + start_year
 )
 
@@ -34,7 +35,16 @@ data <- inner_join(data, site_year, by = c("Site", "Year"))
 
 residual <- rnorm(nrow(data), sd = exp(log_sd))
 
-data <- mutate(data, Density = exp(alpha + beta * (Year - mean(Year)) + (as.integer(HabitatQuality) - 1) * habitat + site_year_effect + residual))
+data <- mutate(
+  data,
+  Density = exp(
+    alpha +
+      beta * (Year - mean(Year)) +
+      (as.integer(HabitatQuality) - 1) * habitat +
+      site_year_effect +
+      residual
+  )
+)
 
 data <- select(data, Site, HabitatQuality, Year, Visit, Density)
 data <- arrange(data, Site, Year, Visit)

--- a/inst/create-test-analyses.R
+++ b/inst/create-test-analyses.R
@@ -174,204 +174,203 @@ if (FALSE) {
         analysis_jags_re,
         "inst/test-objects/analysis_jags_re.RDS"
       )
+    }
+  )
+
+  withr::with_package(package = "smbr", {
+    data <- tibble(
+      mass = as.numeric(1000:1099),
+      species = factor(rep(c("a", "b"), each = 50))
+    )
+
+    niters <- 250L
+
+    # Stan with new expr ----
+    model <- model(
+      code = "
+          data {
+            int<lower=2> nObs;
+            int<lower=1> nspecies;
+            int<lower=1> species[nObs];
+            real<lower=0> mass[nObs];
+          }
+
+          parameters {
+            real bSpecies[nspecies];
+            real<lower=0> sMass;
+          }
+
+          transformed parameters {
+            real eMass[nObs];
+
+            for (i in 1:nObs) {
+              eMass[i] = exp(bSpecies[species[i]]);
+            }
+          }
+
+          model {
+            bSpecies ~ normal(0, 2);
+            sMass ~ exponential(1);
+
+            mass ~ lognormal(log(eMass), sMass);
+          }
+        ",
+      new_expr = "
+          for (i in 1:nObs) {
+            log(eMass[i]) <- bSpecies[species[i]]
+            log_lik[i] <- log_lik_lnorm(mass[i], log(eMass[i]), sMass)
+          }
+          lprior[1] <- sum(log_lik_norm(bSpecies, 0, 2))
+          lprior[2] <- log_lik_exp(sMass, 1)
+        ",
+      select_data = list(
+        species = factor(),
+        mass = c(900, 2000)
+      )
+    )
+
+    analysis_stan_newexpr <- analyse(model, data, niters = niters)
+    analysis_stan_newexpr$stanfit <- NULL
+    saveRDS(
+      analysis_stan_newexpr,
+      "inst/test-objects/analysis_stan_newexpr.RDS"
+    )
+
+    # Stan in model ----
+    model <- model(
+      code = "
+          data {
+            int<lower=2> nObs;
+            int<lower=1> nspecies;
+            int<lower=1> species[nObs];
+            real<lower=0> mass[nObs];
+          }
+
+          parameters {
+            real bSpecies[nspecies];
+            real<lower=0> sMass;
+          }
+
+          transformed parameters {
+            real log_lik[nObs];
+            real eMass[nObs];
+            real lprior;
+
+            for (i in 1:nObs) {
+              eMass[i] = exp(bSpecies[species[i]]);
+              log_lik[i] = lognormal_lpdf(
+                mass[i] | log(eMass[i]), sMass
+              );
+            }
+            lprior =
+              normal_lpdf(bSpecies[1] | 0, 2) +
+              normal_lpdf(bSpecies[2] | 0, 2) +
+              exponential_lpdf(sMass | 1);
+          }
+
+          model {
+            bSpecies ~ normal(0, 2);
+            sMass ~ exponential(1);
+
+            mass ~ lognormal(log(eMass), sMass);
+          }
+        ",
+      new_expr = "
+          for (i in 1:nObs) {
+            log(eMass[i]) <- bSpecies[species[i]]
+          }
+        ",
+      select_data = list(
+        species = factor(),
+        mass = c(900, 2000)
+      ),
+      derived = c("log_lik", "lprior")
+    )
+
+    analysis_stan_mod <- analyse(model, data, niters = niters)
+    analysis_stan_mod$stanfit <- NULL
+    saveRDS(
+      analysis_stan_mod,
+      "inst/test-objects/analysis_stan_mod.RDS"
+    )
+
+    # Stan in both new_expr and model ----
+    model <- model(
+      code = "
+          data {
+            int<lower=2> nObs;
+            int<lower=1> nspecies;
+            int<lower=1> species[nObs];
+            real<lower=0> mass[nObs];
+          }
+
+          parameters {
+            real bSpecies[nspecies];
+            real<lower=0> sMass;
+          }
+
+          transformed parameters {
+            real log_lik[nObs];
+            real eMass[nObs];
+            real lprior;
+
+            for (i in 1:nObs) {
+              eMass[i] = exp(bSpecies[species[i]]);
+              log_lik[i] = lognormal_lpdf(
+                mass[i] | log(eMass[i]), sMass
+              );
+            }
+            lprior =
+              normal_lpdf(bSpecies[1] | 0, 2) +
+              normal_lpdf(bSpecies[2] | 0, 2) +
+              exponential_lpdf(sMass | 1);
+          }
+
+          model {
+            bSpecies ~ normal(0, 2);
+            sMass ~ exponential(1);
+            mass ~ lognormal(log(eMass), sMass);
+          }
+        ",
+      new_expr = "
+          for (i in 1:nObs) {
+            log(eMass[i]) <- bSpecies[species[i]]
+            log_lik[i] <- log_lik_lnorm(mass[i], log(eMass[i]), sMass)
+          }
+          lprior[1] <- sum(log_lik_norm(bSpecies, 0, 2))
+          lprior[2] <- log_lik_exp(sMass, 1)
+        ",
+      new_expr_vec = TRUE,
+      select_data = list(
+        species = factor(),
+        mass = c(900, 2000)
+      ),
+      derived = c("log_lik", "lprior")
+    )
+
+    analysis_stan_both <- analyse(model, data, niters = niters)
+    analysis_stan_both$stanfit <- NULL
+    saveRDS(
+      analysis_stan_both,
+      "inst/test-objects/analysis_stan_both.RDS"
+    )
+
+    # Stan with random effects ----
+    data_re <- withr::with_seed(42, {
+      species <- factor(rep(c("a", "b"), each = 250))
+      year <- factor(rep(1:10, times = 50))
+      b_species <- c(0, 0.05)
+      b_year <- rnorm(10, 0, 0.2)
+      log_emass <- b_species[as.integer(species)] + b_year[as.integer(year)]
+      tibble(
+        mass = rlnorm(500, log_emass, 0.1),
+        species = species,
+        year = year
+      )
     })
 
-  withr::with_package(
-    package = "smbr",
-    {
-      data <- tibble(
-        mass = as.numeric(1000:1099),
-        species = factor(rep(c("a", "b"), each = 50))
-      )
-
-      niters <- 250L
-
-      # Stan with new expr ----
-      model <- model(
-        code = "
-          data {
-            int<lower=2> nObs;
-            int<lower=1> nspecies;
-            int<lower=1> species[nObs];
-            real<lower=0> mass[nObs];
-          }
-
-          parameters {
-            real bSpecies[nspecies];
-            real<lower=0> sMass;
-          }
-
-          transformed parameters {
-            real eMass[nObs];
-
-            for (i in 1:nObs) {
-              eMass[i] = exp(bSpecies[species[i]]);
-            }
-          }
-
-          model {
-            bSpecies ~ normal(0, 2);
-            sMass ~ exponential(1);
-
-            mass ~ lognormal(log(eMass), sMass);
-          }
-        ",
-        new_expr = "
-          for (i in 1:nObs) {
-            log(eMass[i]) <- bSpecies[species[i]]
-            log_lik[i] <- log_lik_lnorm(mass[i], log(eMass[i]), sMass)
-          }
-          lprior[1] <- sum(log_lik_norm(bSpecies, 0, 2))
-          lprior[2] <- log_lik_exp(sMass, 1)
-        ",
-        select_data = list(
-          species = factor(),
-          mass = c(900, 2000)
-        )
-      )
-
-      analysis_stan_newexpr <- analyse(model, data, niters = niters)
-      analysis_stan_newexpr$stanfit <- NULL
-      saveRDS(
-        analysis_stan_newexpr,
-        "inst/test-objects/analysis_stan_newexpr.RDS"
-      )
-
-      # Stan in model ----
-      model <- model(
-        code = "
-          data {
-            int<lower=2> nObs;
-            int<lower=1> nspecies;
-            int<lower=1> species[nObs];
-            real<lower=0> mass[nObs];
-          }
-
-          parameters {
-            real bSpecies[nspecies];
-            real<lower=0> sMass;
-          }
-
-          transformed parameters {
-            real log_lik[nObs];
-            real eMass[nObs];
-            real lprior;
-
-            for (i in 1:nObs) {
-              eMass[i] = exp(bSpecies[species[i]]);
-              log_lik[i] = lognormal_lpdf(
-                mass[i] | log(eMass[i]), sMass
-              );
-            }
-            lprior =
-              normal_lpdf(bSpecies[1] | 0, 2) +
-              normal_lpdf(bSpecies[2] | 0, 2) +
-              exponential_lpdf(sMass | 1);
-          }
-
-          model {
-            bSpecies ~ normal(0, 2);
-            sMass ~ exponential(1);
-
-            mass ~ lognormal(log(eMass), sMass);
-          }
-        ",
-        new_expr = "
-          for (i in 1:nObs) {
-            log(eMass[i]) <- bSpecies[species[i]]
-          }
-        ",
-        select_data = list(
-          species = factor(),
-          mass = c(900, 2000)
-        ),
-        derived = c("log_lik", "lprior")
-      )
-
-      analysis_stan_mod <- analyse(model, data, niters = niters)
-      analysis_stan_mod$stanfit <- NULL
-      saveRDS(
-        analysis_stan_mod,
-        "inst/test-objects/analysis_stan_mod.RDS"
-      )
-
-      # Stan in both new_expr and model ----
-      model <- model(
-        code = "
-          data {
-            int<lower=2> nObs;
-            int<lower=1> nspecies;
-            int<lower=1> species[nObs];
-            real<lower=0> mass[nObs];
-          }
-
-          parameters {
-            real bSpecies[nspecies];
-            real<lower=0> sMass;
-          }
-
-          transformed parameters {
-            real log_lik[nObs];
-            real eMass[nObs];
-            real lprior;
-
-            for (i in 1:nObs) {
-              eMass[i] = exp(bSpecies[species[i]]);
-              log_lik[i] = lognormal_lpdf(
-                mass[i] | log(eMass[i]), sMass
-              );
-            }
-            lprior =
-              normal_lpdf(bSpecies[1] | 0, 2) +
-              normal_lpdf(bSpecies[2] | 0, 2) +
-              exponential_lpdf(sMass | 1);
-          }
-
-          model {
-            bSpecies ~ normal(0, 2);
-            sMass ~ exponential(1);
-            mass ~ lognormal(log(eMass), sMass);
-          }
-        ",
-        new_expr = "
-          for (i in 1:nObs) {
-            log(eMass[i]) <- bSpecies[species[i]]
-            log_lik[i] <- log_lik_lnorm(mass[i], log(eMass[i]), sMass)
-          }
-          lprior[1] <- sum(log_lik_norm(bSpecies, 0, 2))
-          lprior[2] <- log_lik_exp(sMass, 1)
-        ",
-        new_expr_vec = TRUE,
-        select_data = list(
-          species = factor(),
-          mass = c(900, 2000)
-        ),
-        derived = c("log_lik", "lprior")
-      )
-
-      analysis_stan_both <- analyse(model, data, niters = niters)
-      analysis_stan_both$stanfit <- NULL
-      saveRDS(
-        analysis_stan_both,
-        "inst/test-objects/analysis_stan_both.RDS"
-      )
-
-      # Stan with random effects ----
-      data_re <- withr::with_seed(42, {
-        species <- factor(rep(c("a", "b"), each = 250))
-        year <- factor(rep(1:10, times = 50))
-        b_species <- c(0, 0.05)
-        b_year <- rnorm(10, 0, 0.2)
-        log_emass <- b_species[as.integer(species)] + b_year[as.integer(year)]
-        tibble(
-          mass = rlnorm(500, log_emass, 0.1),
-          species = species,
-          year = year
-        )
-      })
-
-      model <- model(
-        code = "
+    model <- model(
+      code = "
           data {
             int<lower=2> nObs;
             int<lower=1> nspecies;
@@ -409,7 +408,7 @@ if (FALSE) {
             mass ~ lognormal(log(eMass), sMass);
           }
         ",
-        new_expr = "
+      new_expr = "
           for (i in 1:nObs) {
             log(eMass[i]) <- bSpecies[species[i]] + bYear[year[i]]
             log_lik[i] <- log_lik_lnorm(mass[i], log(eMass[i]), sMass)
@@ -418,21 +417,20 @@ if (FALSE) {
           lprior[2] <- log_lik_exp(sYear, 1)
           lprior[3] <- log_lik_exp(sMass, 1)
         ",
-        random_effects = list(bYear = "year"),
-        select_data = list(
-          species = factor(),
-          year = factor(),
-          mass = c(0.5, 3)
-        ),
-        derived = "ratio"
-      )
+      random_effects = list(bYear = "year"),
+      select_data = list(
+        species = factor(),
+        year = factor(),
+        mass = c(0.5, 3)
+      ),
+      derived = "ratio"
+    )
 
-      analysis_stan_re <- analyse(model, data_re, niters = 500L)
-      analysis_stan_re$stanfit <- NULL
-      saveRDS(
-        analysis_stan_re,
-        "inst/test-objects/analysis_stan_re.RDS"
-      )
-    }
-  )
+    analysis_stan_re <- analyse(model, data_re, niters = 500L)
+    analysis_stan_re$stanfit <- NULL
+    saveRDS(
+      analysis_stan_re,
+      "inst/test-objects/analysis_stan_re.RDS"
+    )
+  })
 }

--- a/tests/testthat/test-add-nfactors.R
+++ b/tests/testthat/test-add-nfactors.R
@@ -1,8 +1,17 @@
 test_that("add_nfactors", {
   expect_identical(names(add_nfactors(list(x = factor(1)))), c("x", "nx"))
-  expect_identical(names(add_nfactors(list(x = factor(1), y = 1))), c("x", "y", "nx"))
-  expect_identical(names(add_nfactors(list(x = factor(1), y = factor(1:2)))), c("x", "y", "nx", "ny"))
+  expect_identical(
+    names(add_nfactors(list(x = factor(1), y = 1))),
+    c("x", "y", "nx")
+  )
+  expect_identical(
+    names(add_nfactors(list(x = factor(1), y = factor(1:2)))),
+    c("x", "y", "nx", "ny")
+  )
   expect_identical(add_nfactors(list(x = factor(1), y = factor(1:2)))$nx, 1L)
   expect_identical(add_nfactors(list(x = factor(1), Y = factor(1:2)))$nY, 2L)
-  expect_error(add_nfactors(list(x = factor(1), nx = factor(1:2))), "nFactor names are reserved")
+  expect_error(
+    add_nfactors(list(x = factor(1), nx = factor(1:2))),
+    "nFactor names are reserved"
+  )
 })

--- a/tests/testthat/test-add-sensitivity.R
+++ b/tests/testthat/test-add-sensitivity.R
@@ -1,15 +1,24 @@
 test_that("add_sensitivity adds sensitivity field to JAGS analysis", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   result <- add_sensitivity(analysis)
   expect_true(is.data.frame(result$sensitivity))
-  expect_named(result$sensitivity, c("term", "prior", "likelihood", "diagnosis"))
+  expect_named(
+    result$sensitivity,
+    c("term", "prior", "likelihood", "diagnosis")
+  )
 })
 
 test_that("add_sensitivity uses cache on second call", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   a1 <- add_sensitivity(analysis)
   a2 <- add_sensitivity(a1)
@@ -18,7 +27,10 @@ test_that("add_sensitivity uses cache on second call", {
 
 test_that("add_sensitivity replaces cache when replace = TRUE", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   a1 <- add_sensitivity(analysis)
   a2 <- add_sensitivity(a1, replace = TRUE)
@@ -27,7 +39,10 @@ test_that("add_sensitivity replaces cache when replace = TRUE", {
 
 test_that("add_sensitivity retains original new_expr on returned object", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   original_expr <- new_expr(analysis)
   result <- add_sensitivity(analysis)
@@ -43,7 +58,10 @@ test_that("add_sensitivity errors if x is not an mb_analysis object", {
 
 test_that("add_sensitivity errors if replace is not a flag", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     add_sensitivity(analysis, replace = "yes"),

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -2,10 +2,22 @@ test_that("check_drops", {
   expect_identical(check_drops(list()), list())
   expect_identical(check_drops(list("1")), list("1"))
   expect_identical(check_drops(list("1", c("2", "3"))), list("1", c("2", "3")))
-  expect_identical(check_drops(list(c("1", "2"), c("1", "3"))), list(c("1", "2"), c("1", "3")))
-  expect_error(check_drops(list(character(0))), "drops must be a list of non-zero length character vectors")
+  expect_identical(
+    check_drops(list(c("1", "2"), c("1", "3"))),
+    list(c("1", "2"), c("1", "3"))
+  )
+  expect_error(
+    check_drops(list(character(0))),
+    "drops must be a list of non-zero length character vectors"
+  )
   expect_error(check_drops("1"), "drops must be a list")
-  expect_error(check_drops(list(1)), "drops must be a list of character vectors")
-  expect_error(check_drops(list("1", "1")), "drops must be a list of unique character vectors")
+  expect_error(
+    check_drops(list(1)),
+    "drops must be a list of character vectors"
+  )
+  expect_error(
+    check_drops(list("1", "1")),
+    "drops must be a list of unique character vectors"
+  )
   expect_error(check_drops(list("1", c("1", "2"))), "drops is inconsistent")
 })

--- a/tests/testthat/test-code.R
+++ b/tests/testthat/test-code.R
@@ -28,7 +28,6 @@ test_that("analyse", {
   }
 }"
 
-
   code <- mb_code(template)
 
   expect_identical(class(code), c("jmb_code", "mb_code"))
@@ -38,7 +37,11 @@ test_that("analyse", {
   expect_error(pars(code, param_type = "primary"))
   expect_error(pars(code, scalar = TRUE))
 
-  code10 <- sd_priors_by(code, 10, distributions = c("logistic", "normal", "lognormal", "t"))
+  code10 <- sd_priors_by(
+    code,
+    10,
+    distributions = c("logistic", "normal", "lognormal", "t")
+  )
   expect_identical(pars(code10), pars(code))
   expect_identical(
     as.character(code10),

--- a/tests/testthat/test-coef.R
+++ b/tests/testthat/test-coef.R
@@ -1,13 +1,26 @@
 test_that("coef directional_information for Bayesian analysis", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
 
-  coef_svalue <- coef(analysis, simplify = TRUE, directional_information = FALSE)
-  expect_identical(colnames(coef_svalue), c("term", "estimate", "lower", "upper", "svalue"))
+  coef_svalue <- coef(
+    analysis,
+    simplify = TRUE,
+    directional_information = FALSE
+  )
+  expect_identical(
+    colnames(coef_svalue),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
   coef_di <- coef(analysis, simplify = TRUE, directional_information = TRUE)
-  expect_identical(colnames(coef_di), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef_di),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
   expect_identical(
     coef_di[c("term", "estimate", "lower", "upper")],
@@ -24,12 +37,23 @@ test_that("coef directional_information for Bayesian analysis", {
 
 test_that("coef soft-deprecates unset directional_information for Bayesian analysis", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
 
   lifecycle::expect_deprecated(coef(analysis, simplify = TRUE))
-  expect_no_warning(coef(analysis, simplify = TRUE, directional_information = FALSE))
-  expect_no_warning(coef(analysis, simplify = TRUE, directional_information = TRUE))
+  expect_no_warning(coef(
+    analysis,
+    simplify = TRUE,
+    directional_information = FALSE
+  ))
+  expect_no_warning(coef(
+    analysis,
+    simplify = TRUE,
+    directional_information = TRUE
+  ))
 
   chk::expect_chk_error(coef(analysis, directional_information = NA))
 })
@@ -39,6 +63,9 @@ test_that("coef directional_information for null analysis", {
   class(analysis) <- c("mb_null_analysis", "mb_analysis")
 
   coef <- coef(analysis, simplify = TRUE, directional_information = TRUE)
-  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(nrow(coef), 0L)
 })

--- a/tests/testthat/test-drops.R
+++ b/tests/testthat/test-drops.R
@@ -28,24 +28,73 @@ test_that("impossible_drop", {
 test_that("eliminate_drop", {
   expect_identical(eliminate_drop(list("1"), "1"), list())
   expect_identical(eliminate_drop(list("1"), character(0)), list("1"))
-  expect_identical(eliminate_drop(list("1", c("2", "3")), "1"), list(c("2", "3")))
-  expect_identical(eliminate_drop(list("1", c("2", "3")), c("1", "2")), list("3"))
-  expect_identical(eliminate_drop(list(c("1", "2"), c("1", "3")), "1"), list("2", "3"))
+  expect_identical(
+    eliminate_drop(list("1", c("2", "3")), "1"),
+    list(c("2", "3"))
+  )
+  expect_identical(
+    eliminate_drop(list("1", c("2", "3")), c("1", "2")),
+    list("3")
+  )
+  expect_identical(
+    eliminate_drop(list(c("1", "2"), c("1", "3")), "1"),
+    list("2", "3")
+  )
 })
 
 test_that("full_drop", {
   expect_equal(full_drop(list()), character(0))
   expect_equal(full_drop(list("1")), "1")
-  expect_equal(full_drop(list(c("1", "2"), c("1", "3"))), sort(c("1", "2", "3")))
+  expect_equal(
+    full_drop(list(c("1", "2"), c("1", "3"))),
+    sort(c("1", "2", "3"))
+  )
 })
 
 
 test_that("make_all_drops", {
   expect_identical(make_all_drops(list()), list("base" = character(0)))
-  expect_identical(make_all_drops(list("1")), list("full" = character(0), "base" = "1"))
-  expect_identical(make_all_drops(list("1", "2")), list("full" = character(0), "base+2" = "1", "base+1" = "2", "base" = c("1", "2")))
-  expect_identical(make_all_drops(list("2", "1")), list("full" = character(0), "base+2" = "1", "base+1" = "2", "base" = c("1", "2")))
+  expect_identical(
+    make_all_drops(list("1")),
+    list("full" = character(0), "base" = "1")
+  )
+  expect_identical(
+    make_all_drops(list("1", "2")),
+    list(
+      "full" = character(0),
+      "base+2" = "1",
+      "base+1" = "2",
+      "base" = c("1", "2")
+    )
+  )
+  expect_identical(
+    make_all_drops(list("2", "1")),
+    list(
+      "full" = character(0),
+      "base+2" = "1",
+      "base+1" = "2",
+      "base" = c("1", "2")
+    )
+  )
   expect_identical(length(make_all_drops(list("1", "2", "3"))), 8L)
-  expect_identical(make_all_drops(list(c("2", "1", "3"))), list("full" = character(0), "base+1+2" = "3", "base+2" = c("1", "3"), "base" = c("1", "2", "3")))
-  expect_identical(make_all_drops(list("1", c("2", "3"))), list("full" = character(0), "base+2+3" = "1", "base+1+2" = "3", "base+2" = c("1", "3"), "base+1" = c("2", "3"), "base" = c("1", "2", "3")))
+  expect_identical(
+    make_all_drops(list(c("2", "1", "3"))),
+    list(
+      "full" = character(0),
+      "base+1+2" = "3",
+      "base+2" = c("1", "3"),
+      "base" = c("1", "2", "3")
+    )
+  )
+  expect_identical(
+    make_all_drops(list("1", c("2", "3"))),
+    list(
+      "full" = character(0),
+      "base+2+3" = "1",
+      "base+1+2" = "3",
+      "base+2" = c("1", "3"),
+      "base+1" = c("2", "3"),
+      "base" = c("1", "2", "3")
+    )
+  )
 })

--- a/tests/testthat/test-log-lik-draws.R
+++ b/tests/testthat/test-log-lik-draws.R
@@ -2,7 +2,10 @@
 # new expression ----
 test_that("log_lik extracted from new expression in jags model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(lld <- log_lik_draws(analysis))
   expect_equal(dim(lld)[3], nrow(analysis$data))
@@ -10,7 +13,10 @@ test_that("log_lik extracted from new expression in jags model", {
 
 test_that("joint log_lik extracted from new expression in jags model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(lld_joint <- log_lik_draws(analysis, joint = TRUE))
   expect_equal(dim(lld_joint)[3], 1)
@@ -20,7 +26,10 @@ test_that("joint log_lik extracted from new expression in jags model", {
 
 test_that("errors if log_lik_name doesn't match", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     log_lik_draws(analysis, log_lik_name = "elog_lik"),
@@ -30,7 +39,10 @@ test_that("errors if log_lik_name doesn't match", {
 
 test_that("log_lik extracted if different name", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   analysis$model <- update_model(
     analysis$model,
@@ -49,7 +61,10 @@ test_that("log_lik extracted if different name", {
 
 test_that("log_lik extracted from new expression in jags model when new_expr_vec = FALSE", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   lld_vec <- log_lik_draws(analysis)
   analysis$model <- update_model(
@@ -127,7 +142,10 @@ test_that("suggestion from warning when defining log_lik in two places works", {
 # new expression ----
 test_that("log_lik extracted from new expression in stan model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(lld <- log_lik_draws(analysis))
   expect_equal(dim(lld)[3], nrow(analysis$data))
@@ -135,7 +153,10 @@ test_that("log_lik extracted from new expression in stan model", {
 
 test_that("joint log_lik extracted from new expression in stan model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(lld_joint <- log_lik_draws(analysis, joint = TRUE))
   expect_equal(dim(lld_joint)[3], 1)
@@ -145,7 +166,10 @@ test_that("joint log_lik extracted from new expression in stan model", {
 
 test_that("errors if log_lik_name doesn't match", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(
     log_lik_draws(analysis, log_lik_name = "elog_lik"),
@@ -155,7 +179,10 @@ test_that("errors if log_lik_name doesn't match", {
 
 test_that("log_lik extracted if different name", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   analysis$model <- update_model(
     analysis$model,
@@ -174,7 +201,10 @@ test_that("log_lik extracted if different name", {
 
 test_that("log_lik extracted from new expression in stan model when new_expr_vec = FALSE", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   lld_vec <- log_lik_draws(analysis)
   analysis$model <- update_model(
@@ -291,7 +321,10 @@ test_that("log_lik correctly extracted from model when new_expr contains log_lik
 # General ----
 test_that("warnings piped through when lprior and param lengths don't match", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   analysis$model <- update_model(
     analysis$model,

--- a/tests/testthat/test-log-prior-draws.R
+++ b/tests/testthat/test-log-prior-draws.R
@@ -2,7 +2,10 @@
 # new expression ----
 test_that("lprior extracted from new expression in jags model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(lpd <- log_prior_draws(analysis))
   expect_equal(dim(lpd)[3], 2)
@@ -10,7 +13,10 @@ test_that("lprior extracted from new expression in jags model", {
 
 test_that("joint lprior extracted from new expression in jags model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(lpd_joint <- log_prior_draws(analysis, joint = TRUE))
   expect_equal(dim(lpd_joint)[3], 1)
@@ -20,7 +26,10 @@ test_that("joint lprior extracted from new expression in jags model", {
 
 test_that("errors if log_prior_name doesn't match", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     log_prior_draws(analysis, log_prior_name = "elprior"),
@@ -30,7 +39,10 @@ test_that("errors if log_prior_name doesn't match", {
 
 test_that("lprior extracted if different name", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   analysis$model <- update_model(
     analysis$model,
@@ -49,7 +61,10 @@ test_that("lprior extracted if different name", {
 
 test_that("lprior extracted from new expression in jags model when new_expr_vec = FALSE", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   lpd_vec <- log_prior_draws(analysis)
   analysis$model <- update_model(
@@ -127,7 +142,10 @@ test_that("suggestion from warning when defining lprior in two places works", {
 # new expression ----
 test_that("lprior extracted from new expression in stan model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(lpd <- log_prior_draws(analysis))
   expect_equal(dim(lpd)[3], 2)
@@ -135,7 +153,10 @@ test_that("lprior extracted from new expression in stan model", {
 
 test_that("joint lprior extracted from new expression in stan model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(lpd_joint <- log_prior_draws(analysis, joint = TRUE))
   expect_equal(dim(lpd_joint)[3], 1)
@@ -145,7 +166,10 @@ test_that("joint lprior extracted from new expression in stan model", {
 
 test_that("errors if log_prior_name doesn't match", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(
     log_prior_draws(analysis, log_prior_name = "elprior"),
@@ -155,7 +179,10 @@ test_that("errors if log_prior_name doesn't match", {
 
 test_that("lprior extracted if different name", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   analysis$model <- update_model(
     analysis$model,
@@ -174,7 +201,10 @@ test_that("lprior extracted if different name", {
 
 test_that("lprior extracted from new expression in stan model when new_expr_vec = FALSE", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   lpd_vec <- log_prior_draws(analysis)
   analysis$model <- update_model(
@@ -251,7 +281,10 @@ test_that("suggestion from warning when defining lprior in two places works", {
 # General ----
 test_that("warnings piped through when lprior and param lengths don't match", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   analysis$model <- update_model(
     analysis$model,

--- a/tests/testthat/test-mb-null-analysis.R
+++ b/tests/testthat/test-mb-null-analysis.R
@@ -4,7 +4,10 @@ test_that("mb_null_analysis", {
 
   coef <- coef(analysis)
   expect_s3_class(coef, "tbl")
-  expect_identical(colnames(coef), c("term", "estimate", "sd", "zscore", "lower", "upper", "pvalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "sd", "zscore", "lower", "upper", "pvalue")
+  )
   expect_identical(nrow(coef), 0L)
 
   glance <- glance(analysis)

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -49,11 +49,14 @@ test_that("model pars", {
   model <- model(
     code = template,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor")),
     new_expr = new_expr
   )
@@ -107,11 +110,14 @@ test_that("model pars ", {
   model <- model(
     code = template,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|log_)", derived = "bDensity",
+    fixed = "^(b|log_)",
+    derived = "bDensity",
     random_effects = list(rSiteYear = c("Site", "YearFactor")),
     new_expr = new_expr
   )

--- a/tests/testthat/test-new-expr-update.R
+++ b/tests/testthat/test-new-expr-update.R
@@ -42,15 +42,19 @@ test_that("update new expr string expression", {
   }",
     new_expr_vec = FALSE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  model <- update_model(model,
+  model <- update_model(
+    model,
     new_expr = "
             {
           fit <- bIntercept + bYear * Year + bHabitatQuality[HabitatQuality] +
@@ -71,11 +75,21 @@ test_that("update new expr string expression", {
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
@@ -128,33 +142,46 @@ test_that("update new expr bare expression", {
   }",
     new_expr_vec = FALSE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  model <- update_model(model,
-    new_expr = {
-      fit <- bIntercept + bYear * Year + bHabitatQuality[HabitatQuality] +
-        bSiteYear[cbind(Site, YearFactor)]
-      log(prediction) <- fit
-      residual <- res_lnorm(Density, fit, exp(log_sDensity))
-    }
-  )
+  model <- update_model(model, new_expr = {
+    fit <- bIntercept +
+      bYear * Year +
+      bHabitatQuality[HabitatQuality] +
+      bSiteYear[cbind(Site, YearFactor)]
+    log(prediction) <- fit
+    residual <- res_lnorm(Density, fit, exp(log_sDensity))
+  })
   niters <- 250L
   analysis <- analyse(model, data = data, niters = niters, glance = FALSE)
 
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
@@ -206,18 +233,20 @@ test_that("add new_expr_vec argument to update model", {
   }",
     new_expr_vec = TRUE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
   model <- update_model(
     model,
-    new_expr =
-      "
+    new_expr = "
       for(i in 1:length(Density)) {
         fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
         log(prediction[i]) <- fit[i]
@@ -231,11 +260,21 @@ test_that("add new_expr_vec argument to update model", {
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
@@ -287,11 +326,14 @@ test_that("add new_expr_vec argument to update model and updates original new_ex
   }",
     new_expr_vec = FALSE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
@@ -305,11 +347,21 @@ test_that("add new_expr_vec argument to update model and updates original new_ex
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
@@ -361,11 +413,14 @@ test_that("cannot undo the vectorization if orignally set in the model", {
   }",
     new_expr_vec = TRUE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
@@ -379,11 +434,21 @@ test_that("cannot undo the vectorization if orignally set in the model", {
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 

--- a/tests/testthat/test-new-expr-vec.R
+++ b/tests/testthat/test-new-expr-vec.R
@@ -42,36 +42,68 @@ test_that("vectorize predict string expression", {
   }",
     new_expr_vec = TRUE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  expect_warning(expect_warning(analysis <- analyse(model, data = data, glance = TRUE)))
+  expect_warning(expect_warning(
+    analysis <- analyse(model, data = data, glance = TRUE)
+  ))
 
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
   local_edition(3)
@@ -114,44 +146,78 @@ test_that("vectorize predict bare expression", {
     Density[i] ~ dlnorm(eDensity[i], sDensity^-2)
   }
 }",
-    new_expr =
-      for (i in 1:length(Density)) {
-        fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
-        log(prediction[i]) <- fit[i]
-        residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
-      },
+    new_expr = for (i in 1:length(Density)) {
+      fit[i] <- bIntercept +
+        bYear * Year[i] +
+        bHabitatQuality[HabitatQuality[i]] +
+        bSiteYear[Site[i], YearFactor[i]]
+      log(prediction[i]) <- fit[i]
+      residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
+    },
     new_expr_vec = TRUE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  expect_warning(expect_warning(analysis <- analyse(model, data = data, glance = FALSE)))
+  expect_warning(expect_warning(
+    analysis <- analyse(model, data = data, glance = FALSE)
+  ))
 
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
   local_edition(3)
@@ -194,8 +260,7 @@ test_that("two expressions wrapped even when new_expr_vec = TRUE", {
     Density[i] ~ dlnorm(eDensity[i], sDensity^-2)
   }
 }",
-    new_expr =
-      " {
+    new_expr = " {
   for(i in 1:length(Density)) {
     fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
     log(prediction[i]) <- fit[i]
@@ -205,36 +270,68 @@ test_that("two expressions wrapped even when new_expr_vec = TRUE", {
 ",
     new_expr_vec = TRUE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  expect_warning(expect_warning(analysis <- analyse(model, data = data, glance = FALSE)))
+  expect_warning(expect_warning(
+    analysis <- analyse(model, data = data, glance = FALSE)
+  ))
 
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
   local_edition(3)

--- a/tests/testthat/test-new-expr.R
+++ b/tests/testthat/test-new-expr.R
@@ -42,36 +42,68 @@ test_that("predict string expression", {
   }",
     new_expr_vec = FALSE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  expect_warning(expect_warning(analysis <- analyse(model, data = data, glance = FALSE)))
+  expect_warning(expect_warning(
+    analysis <- analyse(model, data = data, glance = FALSE)
+  ))
 
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
   local_edition(3)
@@ -114,44 +146,78 @@ test_that("predict bare expression", {
     Density[i] ~ dlnorm(eDensity[i], sDensity^-2)
   }
 }",
-    new_expr =
-      for (i in 1:length(Density)) {
-        fit[i] <- bIntercept + bYear * Year[i] + bHabitatQuality[HabitatQuality[i]] + bSiteYear[Site[i], YearFactor[i]]
-        log(prediction[i]) <- fit[i]
-        residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
-      },
+    new_expr = for (i in 1:length(Density)) {
+      fit[i] <- bIntercept +
+        bYear * Year[i] +
+        bHabitatQuality[HabitatQuality[i]] +
+        bSiteYear[Site[i], YearFactor[i]]
+      log(prediction[i]) <- fit[i]
+      residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
+    },
     new_expr_vec = FALSE,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor"))
   )
 
-  expect_warning(expect_warning(analysis <- analyse(model, data = data, glance = FALSE)))
+  expect_warning(expect_warning(
+    analysis <- analyse(model, data = data, glance = FALSE)
+  ))
 
   year <- predict(analysis, new_data = "Year")
 
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
   local_edition(3)

--- a/tests/testthat/test-numericize.R
+++ b/tests/testthat/test-numericize.R
@@ -1,20 +1,38 @@
 test_that("days_since_2000", {
   expect_identical(days_since_2000(as.Date("2000-01-01")), 1L)
-  expect_identical(days_since_2000(as.Date(c("1999-12-30", "2000-01-01"))), c(-1L, 1L))
+  expect_identical(
+    days_since_2000(as.Date(c("1999-12-30", "2000-01-01"))),
+    c(-1L, 1L)
+  )
   expect_identical(days_since_2000(as.Date("2000-02-01")), 32L)
 })
 
 test_that("numericize_dates", {
-  expect_identical(numericize_dates(list(Dayte = as.Date("2000-01-01"))), list(Dayte = 1L))
-  expect_identical(numericize_dates(list(Dayte = as.Date(c("1999-12-30", "2000-01-01")))), list(Dayte = c(-1L, 1L)))
+  expect_identical(
+    numericize_dates(list(Dayte = as.Date("2000-01-01"))),
+    list(Dayte = 1L)
+  )
+  expect_identical(
+    numericize_dates(list(Dayte = as.Date(c("1999-12-30", "2000-01-01")))),
+    list(Dayte = c(-1L, 1L))
+  )
 })
 
 test_that("numericize_logicals", {
   expect_identical(numericize_logicals(list(Dayte = TRUE)), list(Dayte = 1L))
-  expect_identical(numericize_logicals(list(Dayte = c(TRUE, FALSE, NA))), list(Dayte = c(1L, 0L, NA)))
+  expect_identical(
+    numericize_logicals(list(Dayte = c(TRUE, FALSE, NA))),
+    list(Dayte = c(1L, 0L, NA))
+  )
 })
 
 test_that("numericize_factors", {
-  expect_identical(numericize_factors(list(Dayte = factor(TRUE))), list(Dayte = 1L))
-  expect_identical(numericize_factors(list(Dayte = factor(c(TRUE, FALSE, NA)))), list(Dayte = c(2L, 1L, NA)))
+  expect_identical(
+    numericize_factors(list(Dayte = factor(TRUE))),
+    list(Dayte = 1L)
+  )
+  expect_identical(
+    numericize_factors(list(Dayte = factor(c(TRUE, FALSE, NA)))),
+    list(Dayte = c(2L, 1L, NA))
+  )
 })

--- a/tests/testthat/test-pars.R
+++ b/tests/testthat/test-pars.R
@@ -1,15 +1,32 @@
 test_that("pars", {
-  expect_warning(new_expr <- mb_code(" fit2 <- a + b * x # c
+  expect_warning(
+    new_expr <- mb_code(
+      " fit2 <- a + b * x # c
                     fit <- a + b * x + bYear[Year]
                      residual <- y - fit
                     for(i in 1:2) {
                      prediction[i] <- fit[i]
-                    }"), "^template type is unrecognised")
+                    }"
+    ),
+    "^template type is unrecognised"
+  )
 
-  expect_identical(pars(new_expr), sort(c(
-    "a", "b", "bYear", "fit", "fit2", "i", "prediction",
-    "residual", "x", "y", "Year"
-  )))
+  expect_identical(
+    pars(new_expr),
+    sort(c(
+      "a",
+      "b",
+      "bYear",
+      "fit",
+      "fit2",
+      "i",
+      "prediction",
+      "residual",
+      "x",
+      "y",
+      "Year"
+    ))
+  )
 
   expect_identical(npars(new_expr), 11L)
 })

--- a/tests/testthat/test-pmbr-check-pmbr.R
+++ b/tests/testthat/test-pmbr-check-pmbr.R
@@ -13,7 +13,8 @@ test_that("check_pmbr()", {
   })))
 })
 
-cli::test_that_cli("check_pmbr() errors",
+cli::test_that_cli(
+  "check_pmbr() errors",
   {
     local_edition(3)
     expect_snapshot(error = TRUE, {

--- a/tests/testthat/test-powerscale-sensitivity.R
+++ b/tests/testthat/test-powerscale-sensitivity.R
@@ -1,13 +1,19 @@
 test_that("powerscale_sensitivity() works for jags model, values set in new expression", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(powerscale_sensitivity(analysis))
 })
 
 test_that("powerscale_sensitivity() works for jags model, values set in model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(powerscale_sensitivity(analysis))
 })
@@ -21,14 +27,20 @@ test_that("powerscale_sensitivity() errors for jags model, values set both new e
 
 test_that("powerscale_sensitivity() works for stan model, values set in new expression", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(powerscale_sensitivity(analysis))
 })
 
 test_that("powerscale_sensitivity() works for stan model, values set in model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(powerscale_sensitivity(analysis))
 })
@@ -42,21 +54,36 @@ test_that("powerscale_sensitivity() errors for stan model, values set both new e
 
 test_that("powerscale_sensitivity same for joint = TRUE as joint = FALSE, jags", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
-  expect_identical(powerscale_sensitivity(analysis), powerscale_sensitivity(analysis, joint = TRUE))
+  expect_identical(
+    powerscale_sensitivity(analysis),
+    powerscale_sensitivity(analysis, joint = TRUE)
+  )
 })
 
 test_that("powerscale_sensitivity same for joint = TRUE as joint = FALSE, stan", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
-  expect_identical(powerscale_sensitivity(analysis), powerscale_sensitivity(analysis, joint = TRUE))
+  expect_identical(
+    powerscale_sensitivity(analysis),
+    powerscale_sensitivity(analysis, joint = TRUE)
+  )
 })
 
 test_that("powerscale_sensitivity different if lprior and param lengths don't match", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   ps1 <- powerscale_sensitivity(analysis)
   analysis$model <- update_model(
@@ -77,7 +104,10 @@ test_that("powerscale_sensitivity different if lprior and param lengths don't ma
 
 test_that("powerscale_sensitivity same if we sum the lprior for vector of params", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   ps1 <- powerscale_sensitivity(analysis)
   analysis$model <- update_model(
@@ -98,7 +128,10 @@ test_that("powerscale_sensitivity same if we sum the lprior for vector of params
 
 test_that("can subset variables to check", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(powerscale_sensitivity(analysis, variable = "sMass"))
   expect_snapshot(powerscale_sensitivity(analysis, variable = "bSpecies"))
@@ -106,7 +139,10 @@ test_that("can subset variables to check", {
 
 test_that("can change components to check", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(powerscale_sensitivity(analysis, component = "prior"))
   expect_snapshot(powerscale_sensitivity(analysis, component = "likelihood"))
@@ -114,29 +150,48 @@ test_that("can change components to check", {
 
 test_that("can change sensitivity threshold", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
-  expect_snapshot(ps1 <- powerscale_sensitivity(analysis, sensitivity_threshold = 0.1))
-  expect_snapshot(ps2 <- powerscale_sensitivity(analysis, sensitivity_threshold = 0.0001))
+  expect_snapshot(
+    ps1 <- powerscale_sensitivity(analysis, sensitivity_threshold = 0.1)
+  )
+  expect_snapshot(
+    ps2 <- powerscale_sensitivity(analysis, sensitivity_threshold = 0.0001)
+  )
   expect_false(all(ps1 == ps2))
 })
 
 test_that("errors if you try to change log_lik_fn", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   llf2 <- function(x) {
     print(x)
   }
-  expect_snapshot(powerscale_sensitivity(analysis, log_lik_fn = llf2), error = TRUE)
+  expect_snapshot(
+    powerscale_sensitivity(analysis, log_lik_fn = llf2),
+    error = TRUE
+  )
 })
 
 test_that("errors if you try to change log_prior_fn", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   lpf2 <- function(x) {
     print(x)
   }
-  expect_snapshot(powerscale_sensitivity(analysis, log_lik_fn = lpf2), error = TRUE)
+  expect_snapshot(
+    powerscale_sensitivity(analysis, log_lik_fn = lpf2),
+    error = TRUE
+  )
 })

--- a/tests/testthat/test-priorsense-helpers.R
+++ b/tests/testthat/test-priorsense-helpers.R
@@ -23,7 +23,7 @@ test_that("rowsums_draws works with basic draws_array", {
 
   # Check actual values - manually calculate expected sums
   expected_sums <- array(c(15, 18, 21, 24), dim = c(2, 2, 1))
-  expect_equal(matrix(result[, , 1], nrow = 2, ncol = 2), expected_sums[, , 1])
+  expect_equal(matrix(result[,, 1], nrow = 2, ncol = 2), expected_sums[,, 1])
 })
 
 test_that("rowsums_draws preserves chain structure", {
@@ -55,7 +55,7 @@ test_that("rowsums_draws works with single variable", {
   # With single variable, rowsums should equal original values
   dimnames(result)$variable <- NULL
   dimnames(x)$variable <- NULL
-  expect_equal(as.array(result)[, , 1], as.array(x)[, , 1])
+  expect_equal(as.array(result)[,, 1], as.array(x)[,, 1])
 })
 
 test_that("rowsums_draws works with draws_matrix input", {

--- a/tests/testthat/test-sensitivity.R
+++ b/tests/testthat/test-sensitivity.R
@@ -1,6 +1,9 @@
 test_that("sensitivity summarizes by 'all' for JAGS model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = "all") |>
@@ -10,7 +13,10 @@ test_that("sensitivity summarizes by 'all' for JAGS model", {
 
 test_that("sensitivity summarizes by 'parameter' for JAGS model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = "parameter") |>
@@ -20,7 +26,10 @@ test_that("sensitivity summarizes by 'parameter' for JAGS model", {
 
 test_that("sensitivity summarizes by 'term' for JAGS model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = "term") |>
@@ -30,7 +39,10 @@ test_that("sensitivity summarizes by 'term' for JAGS model", {
 
 test_that("sensitivity summarizes by 'all' for Stan model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = "all") |>
@@ -40,7 +52,10 @@ test_that("sensitivity summarizes by 'all' for Stan model", {
 
 test_that("sensitivity summarizes by 'parameter' for Stan model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = "parameter") |>
@@ -50,7 +65,10 @@ test_that("sensitivity summarizes by 'parameter' for Stan model", {
 
 test_that("sensitivity summarizes by 'term' for Stan model", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_stan_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_stan_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = "term") |>
@@ -148,7 +166,10 @@ test_that("sensitivity errors if x is not an mb_analysis object", {
 
 test_that("sensitivity errors if `by` is not a string", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = 10),
@@ -158,7 +179,10 @@ test_that("sensitivity errors if `by` is not a string", {
 
 test_that("sensitivity errors if `by` is NA", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = NA),
@@ -168,7 +192,10 @@ test_that("sensitivity errors if `by` is NA", {
 
 test_that("sensitivity errors if `by` is character(0)", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = character(0)),
@@ -178,7 +205,10 @@ test_that("sensitivity errors if `by` is character(0)", {
 
 test_that("sensitivity errors if other `by` argument provided", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = "total"),
@@ -188,7 +218,10 @@ test_that("sensitivity errors if other `by` argument provided", {
 
 test_that("sensitivity errors if `param_type` is not a string", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, param_type = 10),
@@ -198,7 +231,10 @@ test_that("sensitivity errors if `param_type` is not a string", {
 
 test_that("sensitivity errors if `param_type` is NA", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, param_type = NA),
@@ -208,7 +244,10 @@ test_that("sensitivity errors if `param_type` is NA", {
 
 test_that("sensitivity errors if `param_type` is character(0)", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, param_type = character(0)),
@@ -218,7 +257,10 @@ test_that("sensitivity errors if `param_type` is character(0)", {
 
 test_that("sensitivity errors if `param_type` is not valid", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, param_type = "other"),
@@ -228,7 +270,10 @@ test_that("sensitivity errors if `param_type` is not valid", {
 
 test_that("sensitivity errors if `mb.prior_cjs` is not a number", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, mb.prior_cjs = "high"),
@@ -238,7 +283,10 @@ test_that("sensitivity errors if `mb.prior_cjs` is not a number", {
 
 test_that("sensitivity errors if `mb.prior_cjs` is NA", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, mb.prior_cjs = NA),
@@ -248,7 +296,10 @@ test_that("sensitivity errors if `mb.prior_cjs` is NA", {
 
 test_that("sensitivity errors if `mb.prior_cjs` is numeric(0)", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, mb.prior_cjs = numeric(0)),
@@ -258,7 +309,10 @@ test_that("sensitivity errors if `mb.prior_cjs` is numeric(0)", {
 
 test_that("sensitivity errors if `mb.lik_cjs` is not a number", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, mb.lik_cjs = "high"),
@@ -268,7 +322,10 @@ test_that("sensitivity errors if `mb.lik_cjs` is not a number", {
 
 test_that("sensitivity errors if `mb.lik_cjs` is NA", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, mb.lik_cjs = NA),
@@ -278,7 +335,10 @@ test_that("sensitivity errors if `mb.lik_cjs` is NA", {
 
 test_that("sensitivity errors if `mb.lik_cjs` is numeric(0)", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, mb.lik_cjs = numeric(0)),
@@ -298,7 +358,10 @@ test_that("sensitivity mb.prior_cjs changes weak_prior classification", {
 
 test_that("sensitivity mb.lik_cjs changes strong_data classification", {
   analysis <- readRDS(
-    file = system.file(package = "embr", "test-objects/analysis_jags_newexpr.RDS")
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
   )
   expect_snapshot(
     sensitivity(analysis, by = "all", mb.lik_cjs = 0.12) |>

--- a/tests/testthat/test-simulate-residuals.R
+++ b/tests/testthat/test-simulate-residuals.R
@@ -8,10 +8,17 @@ test_that("edit_residuals_code", {
     edit_residuals_code(rlang::expr(residual <- res_bern(x)), type = "dev")
   })
   expect_snapshot({
-    edit_residuals_code(rlang::expr(residual[i] <- res_bern(x)), simulate = TRUE)
+    edit_residuals_code(
+      rlang::expr(residual[i] <- res_bern(x)),
+      simulate = TRUE
+    )
   })
   expect_snapshot({
-    edit_residuals_code(rlang::expr(residual[i] <- res_bern(x)), type = "data", simulate = TRUE)
+    edit_residuals_code(
+      rlang::expr(residual[i] <- res_bern(x)),
+      type = "data",
+      simulate = TRUE
+    )
   })
   expect_snapshot({
     edit_residuals_code(
@@ -25,7 +32,8 @@ test_that("edit_residuals_code", {
   })
 })
 
-cli::test_that_cli("edit_residuals_code errors when lhs does not start with res",
+cli::test_that_cli(
+  "edit_residuals_code errors when lhs does not start with res",
   {
     local_edition(3)
     expect_snapshot(error = TRUE, {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -43,7 +43,10 @@ test_that("response_lm", {
 })
 
 test_that("indexes", {
-  expect_identical(indexes(c("a", "b", "bYear[1,1]", "bYear[1,2,4,1]")), c("", "", "[1,1]", "[1,2,4,1]"))
+  expect_identical(
+    indexes(c("a", "b", "bYear[1,1]", "bYear[1,2,4,1]")),
+    c("", "", "[1,1]", "[1,2,4,1]")
+  )
   expect_identical(indexes("bIntercept[i]"), "[i]")
 })
 
@@ -59,27 +62,57 @@ test_that("is_namedlist", {
 })
 
 test_that("syntactic", {
-  expect_identical(is.syntactic(c("0", "x", "1x", "x y", "x1")), c(FALSE, TRUE, FALSE, FALSE, TRUE))
+  expect_identical(
+    is.syntactic(c("0", "x", "1x", "x y", "x1")),
+    c(FALSE, TRUE, FALSE, FALSE, TRUE)
+  )
 })
 
 test_that("sort_nlist", {
   expect_identical(sort_nlist(list()), list())
-  expect_identical(sort_nlist(list(y = 2, x = 1, a = 10)), list(a = 10, x = 1, y = 2))
+  expect_identical(
+    sort_nlist(list(y = 2, x = 1, a = 10)),
+    list(a = 10, x = 1, y = 2)
+  )
 })
 
 test_that("scalar_nlist", {
   expect_identical(scalar_nlist(list()), list())
-  expect_identical(scalar_nlist(list(y = 2, x = 1, a = 10)), list(y = 2, x = 1, a = 10))
-  expect_identical(scalar_nlist(list(y = 1:2, x = 1, a = c(3, 10))), list(x = 1))
+  expect_identical(
+    scalar_nlist(list(y = 2, x = 1, a = 10)),
+    list(y = 2, x = 1, a = 10)
+  )
+  expect_identical(
+    scalar_nlist(list(y = 1:2, x = 1, a = c(3, 10))),
+    list(x = 1)
+  )
 })
 
 test_that("model_names", {
   expect_identical(model_names(list(character(0)), list("1")), "full")
-  expect_identical(model_names(list(character(0), "a"), list("a")), c("full", "base"))
-  expect_identical(model_names(list(character(0), "a"), list(c("a", "b"))), c("full", "base+b"))
-  expect_identical(model_names(list(character(0), "a"), list(c("b", "a"))), c("full", "base+b"))
-  expect_identical(model_names(list("b", "a"), list(c("b", "a"))), c("base+a", "base+b"))
-  expect_identical(model_names(list("a", "b"), list(c("b", "a"))), c("base+b", "base+a"))
-  expect_identical(model_names(list("a", character(0), c("b", "a")), list("a", "b")), c("base+b", "full", "base"))
+  expect_identical(
+    model_names(list(character(0), "a"), list("a")),
+    c("full", "base")
+  )
+  expect_identical(
+    model_names(list(character(0), "a"), list(c("a", "b"))),
+    c("full", "base+b")
+  )
+  expect_identical(
+    model_names(list(character(0), "a"), list(c("b", "a"))),
+    c("full", "base+b")
+  )
+  expect_identical(
+    model_names(list("b", "a"), list(c("b", "a"))),
+    c("base+a", "base+b")
+  )
+  expect_identical(
+    model_names(list("a", "b"), list(c("b", "a"))),
+    c("base+b", "base+a")
+  )
+  expect_identical(
+    model_names(list("a", character(0), c("b", "a")), list("a", "b")),
+    c("base+b", "full", "base")
+  )
   expect_error(model_names(list(character(0), "a"), list()))
 })

--- a/tests/testthat/test-zzz-analyse-cmdstan.R
+++ b/tests/testthat/test-zzz-analyse-cmdstan.R
@@ -1,23 +1,21 @@
-test_that(
-  "model pars for smbr2 and cmdstan engine",
-  {
-    skip_if_not_installed("smbr2")
-    skip_if_not_installed("cmdstanr")
-    skip_if(
-      inherits(
-        tryCatch(cmdstanr::cmdstan_path(), error = identity),
-        "error"
-      ),
-      "CmdStan not installed"
-    )
+test_that("model pars for smbr2 and cmdstan engine", {
+  skip_if_not_installed("smbr2")
+  skip_if_not_installed("cmdstanr")
+  skip_if(
+    inherits(
+      tryCatch(cmdstanr::cmdstan_path(), error = identity),
+      "error"
+    ),
+    "CmdStan not installed"
+  )
 
-    library(smbr2)
-    data <- embr::density99
-    data$YearFactor <- factor(data$Year)
+  library(smbr2)
+  data <- embr::density99
+  data$YearFactor <- factor(data$Year)
 
-    set_analysis_mode("quick")
+  set_analysis_mode("quick")
 
-    template <- "data {
+  template <- "data {
   int<lower=0> nObs;
   vector[nObs] Density;
   vector[nObs] Year;
@@ -61,7 +59,7 @@ model {
   }
 }"
 
-    new_expr <- "
+  new_expr <- "
   for(i in 1:length(Density)) {
      eHabitatQuality[2] <- bHabitatQuality
      eHabitatQuality[1] <- 0
@@ -70,60 +68,87 @@ model {
     residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
 } "
 
-    model <- model(
-      code = template,
-      select_data = list(
-        "Year+" = numeric(), YearFactor = factor(),
-        Site = factor(), Density = numeric(),
-        HabitatQuality = factor()
-      ),
-      fixed = "^(b|l)", derived = "eDensity",
-      random_effects = list(bSiteYear = c("Site", "YearFactor")),
-      new_expr = new_expr
+  model <- model(
+    code = template,
+    select_data = list(
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
+      HabitatQuality = factor()
+    ),
+    fixed = "^(b|l)",
+    derived = "eDensity",
+    random_effects = list(bSiteYear = c("Site", "YearFactor")),
+    new_expr = new_expr
+  )
+
+  seed <- 123
+  niters <- 250L
+  nchains <- 2L
+  expect_output(
+    analysis <- analyse(
+      model,
+      data = data,
+      stan_engine = "cmdstan-mcmc",
+      parallel = TRUE,
+      niters = niters,
+      nchains = nchains,
+      niters_warmup = niters,
+      seed = seed
     )
+  )
 
-    seed <- 123
-    niters <- 250L
-    nchains <- 2L
-    expect_output(analysis <- analyse(model,
-      data = data, stan_engine = "cmdstan-mcmc",
-      parallel = TRUE, niters = niters, nchains = nchains,
-      niters_warmup = niters, seed = seed
+  analysis_bare <- analysis
+  analysis_bare$duration <- NULL
+  analysis_bare$stanfit <- NULL
+  analysis_bare$model <- NULL
+  expect_snapshot(analysis_bare)
+
+  expect_output(analysis <- reanalyse(analysis, seed = seed))
+
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
     ))
+  )
+  expect_identical(pars(analysis, "random"), "bSiteYear")
+  expect_identical(pars(analysis, "derived"), "eDensity")
 
-    analysis_bare <- analysis
-    analysis_bare$duration <- NULL
-    analysis_bare$stanfit <- NULL
-    analysis_bare$model <- NULL
-    expect_snapshot(analysis_bare)
+  expect_equal(as.data.frame(data_set(analysis)), data)
 
-    expect_output(analysis <- reanalyse(analysis, seed = seed))
+  expect_s3_class(as.mcmcr(analysis), "mcmcr")
 
-    expect_identical(pars(analysis, "fixed"), sort(c("bHabitatQuality", "bIntercept", "bYear", "log_sDensity", "log_sSiteYear")))
-    expect_identical(pars(analysis, "random"), "bSiteYear")
-    expect_identical(pars(analysis, "derived"), "eDensity")
+  glance <- glance(analysis)
+  expect_snapshot(glance)
 
-    expect_equal(as.data.frame(data_set(analysis)), data)
+  coef <- coef(analysis, simplify = TRUE, directional_information = FALSE)
+  expect_snapshot(coef)
 
-    expect_s3_class(as.mcmcr(analysis), "mcmcr")
+  derived <- coef(
+    analysis,
+    param_type = "derived",
+    simplify = TRUE,
+    directional_information = FALSE
+  )
+  expect_snapshot(derived)
 
-    glance <- glance(analysis)
-    expect_snapshot(glance)
+  tidy <- tidy(analysis)
+  expect_snapshot(tidy)
 
-    coef <- coef(analysis, simplify = TRUE, directional_information = FALSE)
-    expect_snapshot(coef)
+  year <- predict(analysis, new_data = "Year")
+  expect_snapshot(year)
 
-    derived <- coef(analysis, param_type = "derived", simplify = TRUE, directional_information = FALSE)
-    expect_snapshot(derived)
-
-    tidy <- tidy(analysis)
-    expect_snapshot(tidy)
-
-    year <- predict(analysis, new_data = "Year")
-    expect_snapshot(year)
-
-    dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
-    expect_snapshot(dd)
-    expect_true(mcmcdata::is.mcmc_data(dd))
-  }
-)
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
+  expect_snapshot(dd)
+  expect_true(mcmcdata::is.mcmc_data(dd))
+})

--- a/tests/testthat/test-zzz-analyse-rstan.R
+++ b/tests/testthat/test-zzz-analyse-rstan.R
@@ -1,24 +1,22 @@
-test_that(
-  "model pars for smbr2 and cmdstan engine",
-  {
-    skip_if_not_installed("smbr")
-    skip_if_not_installed("rstan")
-    skip_if_not_installed("BH")
-    # MCMC trajectories diverge across R / rstan / Boost combos; snapshots
-    # stay locked to one platform. Skip on R-devel where the toolchain
-    # drifts ahead of the recorded values.
-    skip_if(
-      R.version$status == "Under development (unstable)",
-      "R-devel: rstan snapshot tolerance unreliable"
-    )
+test_that("model pars for smbr2 and cmdstan engine", {
+  skip_if_not_installed("smbr")
+  skip_if_not_installed("rstan")
+  skip_if_not_installed("BH")
+  # MCMC trajectories diverge across R / rstan / Boost combos; snapshots
+  # stay locked to one platform. Skip on R-devel where the toolchain
+  # drifts ahead of the recorded values.
+  skip_if(
+    R.version$status == "Under development (unstable)",
+    "R-devel: rstan snapshot tolerance unreliable"
+  )
 
-    library(smbr)
-    data <- embr::density99
-    data$YearFactor <- factor(data$Year)
+  library(smbr)
+  data <- embr::density99
+  data$YearFactor <- factor(data$Year)
 
-    set_analysis_mode("quick")
+  set_analysis_mode("quick")
 
-    template <- "data {
+  template <- "data {
   int<lower=0> nObs;
   vector[nObs] Density;
   vector[nObs] Year;
@@ -62,7 +60,7 @@ model {
   }
 }"
 
-    new_expr <- "
+  new_expr <- "
   for(i in 1:length(Density)) {
      eHabitatQuality[2] <- bHabitatQuality
      eHabitatQuality[1] <- 0
@@ -71,59 +69,84 @@ model {
     residual[i] <- res_lnorm(Density[i], fit[i], exp(log_sDensity))
 } "
 
-    model <- model(
-      code = template,
-      select_data = list(
-        "Year+" = numeric(), YearFactor = factor(),
-        Site = factor(), Density = numeric(),
-        HabitatQuality = factor()
-      ),
-      fixed = "^(b|l)", derived = "eDensity",
-      random_effects = list(bSiteYear = c("Site", "YearFactor")),
-      new_expr = new_expr
-    )
+  model <- model(
+    code = template,
+    select_data = list(
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
+      HabitatQuality = factor()
+    ),
+    fixed = "^(b|l)",
+    derived = "eDensity",
+    random_effects = list(bSiteYear = c("Site", "YearFactor")),
+    new_expr = new_expr
+  )
 
-    niters <- 250L
-    nchains <- 2L
-    expect_output(analysis <- analyse(model,
+  niters <- 250L
+  nchains <- 2L
+  expect_output(
+    analysis <- analyse(
+      model,
       data = data,
-      parallel = FALSE, niters = niters,
-      nchains = nchains, seed = 1
+      parallel = FALSE,
+      niters = niters,
+      nchains = nchains,
+      seed = 1
+    )
+  )
+
+  analysis_bare <- analysis
+  analysis_bare$duration <- NULL
+  analysis_bare$stanfit <- NULL
+  analysis_bare$model <- NULL
+  expect_snapshot(analysis_bare)
+
+  expect_output(analysis <- reanalyse(analysis, seed = 1))
+
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
     ))
+  )
+  expect_identical(pars(analysis, "random"), "bSiteYear")
+  expect_identical(pars(analysis, "derived"), "eDensity")
 
-    analysis_bare <- analysis
-    analysis_bare$duration <- NULL
-    analysis_bare$stanfit <- NULL
-    analysis_bare$model <- NULL
-    expect_snapshot(analysis_bare)
+  expect_equal(as.data.frame(data_set(analysis)), data)
 
-    expect_output(analysis <- reanalyse(analysis, seed = 1))
+  expect_s3_class(as.mcmcr(analysis), "mcmcr")
 
-    expect_identical(pars(analysis, "fixed"), sort(c("bHabitatQuality", "bIntercept", "bYear", "log_sDensity", "log_sSiteYear")))
-    expect_identical(pars(analysis, "random"), "bSiteYear")
-    expect_identical(pars(analysis, "derived"), "eDensity")
+  glance <- glance(analysis)
+  expect_snapshot(glance)
 
-    expect_equal(as.data.frame(data_set(analysis)), data)
+  coef <- coef(analysis, simplify = TRUE, directional_information = FALSE)
+  expect_snapshot(coef)
 
-    expect_s3_class(as.mcmcr(analysis), "mcmcr")
+  derived <- coef(
+    analysis,
+    param_type = "derived",
+    simplify = TRUE,
+    directional_information = FALSE
+  )
+  expect_snapshot(derived)
 
-    glance <- glance(analysis)
-    expect_snapshot(glance)
+  tidy <- tidy(analysis)
+  expect_snapshot(tidy)
 
-    coef <- coef(analysis, simplify = TRUE, directional_information = FALSE)
-    expect_snapshot(coef)
+  year <- predict(analysis, new_data = "Year")
+  expect_snapshot(year)
 
-    derived <- coef(analysis, param_type = "derived", simplify = TRUE, directional_information = FALSE)
-    expect_snapshot(derived)
-
-    tidy <- tidy(analysis)
-    expect_snapshot(tidy)
-
-    year <- predict(analysis, new_data = "Year")
-    expect_snapshot(year)
-
-    dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
-    expect_snapshot(dd)
-    expect_true(mcmcdata::is.mcmc_data(dd))
-  }
-)
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
+  expect_snapshot(dd)
+  expect_true(mcmcdata::is.mcmc_data(dd))
+})

--- a/tests/testthat/test-zzz-analyse.R
+++ b/tests/testthat/test-zzz-analyse.R
@@ -44,16 +44,21 @@ test_that("analyse", {
   model <- model(
     code = jags_template,
     select_data = list(
-      "Year+" = numeric(), YearFactor = factor(),
-      Site = factor(), Density = numeric(),
+      "Year+" = numeric(),
+      YearFactor = factor(),
+      Site = factor(),
+      Density = numeric(),
       HabitatQuality = factor()
     ),
-    fixed = "^(b|l)", derived = "eDensity",
+    fixed = "^(b|l)",
+    derived = "eDensity",
     random_effects = list(bSiteYear = c("Site", "YearFactor")),
     new_expr = new_expr
   )
 
-  expect_output(expect_warning(expect_warning(analysis <- analyse(model, data = data))))
+  expect_output(expect_warning(expect_warning(
+    analysis <- analyse(model, data = data)
+  )))
 
   expect_equal(as.data.frame(data_set(analysis)), data)
   data2 <- data_set(analysis, marginalize_random_effects = TRUE)
@@ -80,69 +85,158 @@ test_that("analyse", {
   expect_identical(niters(analysis), 10L)
   expect_identical(ngens(analysis), 40L)
 
-
-  expect_identical(pars(analysis, "fixed"), sort(c("bHabitatQuality", "bIntercept", "bYear", "log_sDensity", "log_sSiteYear")))
+  expect_identical(
+    pars(analysis, "fixed"),
+    sort(c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
   expect_identical(pars(analysis, "random"), "bSiteYear")
   expect_identical(pars(analysis, "derived"), "eDensity")
   expect_identical(
     pars(analysis, "primary"),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
   expect_identical(
     pars(analysis),
-    c("bHabitatQuality", "bIntercept", "bSiteYear", "bYear", "eDensity", "log_sDensity", "log_sSiteYear")
+    c(
+      "bHabitatQuality",
+      "bIntercept",
+      "bSiteYear",
+      "bYear",
+      "eDensity",
+      "log_sDensity",
+      "log_sSiteYear"
+    )
   )
 
   expect_s3_class(as.mcmcr(analysis), "mcmcr")
 
   glance <- glance(analysis)
   expect_s3_class(glance, "tbl")
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged"))
+  expect_identical(
+    colnames(glance),
+    c("n", "K", "nchains", "niters", "nthin", "ess", "rhat", "converged")
+  )
   expect_identical(glance$n, 300L)
   expect_identical(glance$nthin, 1L)
   expect_identical(glance$K, 5L)
 
-  derived <- coef(analysis, param_type = "derived", simplify = TRUE, directional_information = FALSE)
-  expect_identical(colnames(derived), c("term", "estimate", "lower", "upper", "svalue"))
+  derived <- coef(
+    analysis,
+    param_type = "derived",
+    simplify = TRUE,
+    directional_information = FALSE
+  )
+  expect_identical(
+    colnames(derived),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(nrow(derived), 300L)
 
   coef <- coef(analysis, simplify = TRUE, directional_information = FALSE)
 
   expect_s3_class(coef, "tbl")
-  expect_identical(colnames(coef), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
 
-  expect_identical(coef$term, as.term(c(
-    "bHabitatQuality[1]", "bHabitatQuality[2]",
-    "bIntercept", "bYear",
-    "log_sDensity", "log_sSiteYear"
-  )))
+  expect_identical(
+    coef$term,
+    as.term(c(
+      "bHabitatQuality[1]",
+      "bHabitatQuality[2]",
+      "bIntercept",
+      "bYear",
+      "log_sDensity",
+      "log_sSiteYear"
+    ))
+  )
 
-  expect_identical(nrow(coef(analysis, "primary", simplify = TRUE, directional_information = FALSE)), 66L)
-  expect_identical(nrow(coef(analysis, "all", simplify = TRUE, directional_information = FALSE)), 366L)
+  expect_identical(
+    nrow(coef(
+      analysis,
+      "primary",
+      simplify = TRUE,
+      directional_information = FALSE
+    )),
+    66L
+  )
+  expect_identical(
+    nrow(coef(
+      analysis,
+      "all",
+      simplify = TRUE,
+      directional_information = FALSE
+    )),
+    366L
+  )
 
   tidy <- tidy(analysis)
-  expect_identical(colnames(tidy), c("term", "estimate", "lower", "upper", "esr", "rhat"))
+  expect_identical(
+    colnames(tidy),
+    c("term", "estimate", "lower", "upper", "esr", "rhat")
+  )
 
   year <- predict(analysis, new_data = "Year")
 
   ppc <- posterior_predictive_check(analysis)
 
   expect_s3_class(ppc, "tbl_df")
-  expect_identical(colnames(ppc), c("moment", "observed", "median", "lower", "upper", "svalue"))
-  expect_identical(ppc$moment, structure(1:5, .Label = c(
-    "zeros", "mean", "variance", "skewness",
-    "kurtosis"
-  ), class = "factor"))
+  expect_identical(
+    colnames(ppc),
+    c("moment", "observed", "median", "lower", "upper", "svalue")
+  )
+  expect_identical(
+    ppc$moment,
+    structure(
+      1:5,
+      .Label = c(
+        "zeros",
+        "mean",
+        "variance",
+        "skewness",
+        "kurtosis"
+      ),
+      class = "factor"
+    )
+  )
   expect_s3_class(year, "tbl")
-  expect_identical(colnames(year), c(
-    "Site", "HabitatQuality", "Year", "Visit",
-    "Density", "YearFactor",
-    "estimate", "lower", "upper", "svalue"
-  ))
+  expect_identical(
+    colnames(year),
+    c(
+      "Site",
+      "HabitatQuality",
+      "Year",
+      "Visit",
+      "Density",
+      "YearFactor",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
+  )
   expect_true(all(year$lower < year$estimate))
   expect_false(is.unsorted(year$estimate))
 
-  dd <- mcmc_derive_data(analysis, new_data = c("Site", "Year"), ref_data = TRUE)
+  dd <- mcmc_derive_data(
+    analysis,
+    new_data = c("Site", "Year"),
+    ref_data = TRUE
+  )
   expect_true(mcmcdata::is.mcmc_data(dd))
 
   expect_warning(expect_warning(expect_warning(
@@ -173,5 +267,17 @@ test_that("analyse", {
 
   expect_s3_class(glance, "tbl")
   expect_identical(nrow(glance), 1L)
-  expect_identical(colnames(glance), c("n", "K", "nchains", "niters", "rhat_1", "rhat_2", "rhat_all", "converged"))
+  expect_identical(
+    colnames(glance),
+    c(
+      "n",
+      "K",
+      "nchains",
+      "niters",
+      "rhat_1",
+      "rhat_2",
+      "rhat_all",
+      "converged"
+    )
+  )
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)