### PR TITLE
Make coef(simplify = FALSE) defunct and default to simplify = TRUE

### DIFF
--- a/R/coef.R
+++ b/R/coef.R
@@ -36,7 +36,7 @@ coef.mb_null_analysis <- function(
   include_constant = TRUE,
   conf_level = getOption("mb.conf_level", 0.95),
   estimate = getOption("mb.estimate", median),
-  simplify = FALSE,
+  simplify = TRUE,
   directional_information = FALSE,
   ...
 ) {
@@ -47,6 +47,10 @@ coef.mb_null_analysis <- function(
   chk_range(conf_level, c(0.5, 0.99))
   chk_flag(simplify)
   chk_flag(directional_information)
+
+  if (!simplify) {
+    lifecycle::deprecate_stop("1.1.0", "coef(simplify = 'must be TRUE')")
+  }
 
   coef <- tibble(
     term = as_term(character(0)),
@@ -57,17 +61,15 @@ coef.mb_null_analysis <- function(
 
   coef <- get_frequentist_coef(coef)
 
-  if (simplify) {
-    coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
-    coef <- select(
-      coef,
-      "term",
-      "estimate",
-      "lower",
-      "upper",
-      "svalue"
-    )
-  }
+  coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
+  coef <- select(
+    coef,
+    "term",
+    "estimate",
+    "lower",
+    "upper",
+    "svalue"
+  )
 
   class(coef) <- c("mb_analysis_coef", class(coef))
 
@@ -78,14 +80,13 @@ coef.mb_null_analysis <- function(
 #'
 #' Coefficients for a JAGS analysis.
 #'
-#' The `zscore` is mean / sd.
-#'
 #' @param object The mb_analysis object.
 #' @param param_type A flag specifying whether 'fixed', 'random' or 'derived' terms.
 #' @param include_constant A flag specifying whether to include constant terms.
 #' @param conf_level A number specifying the confidence level. By default 0.95.
 #' @param estimate The function to use to calculating the estimate for Bayesian models.
-#' @param simplify A flag specifying whether to drop sd and zscore columns and return svalue instead of pvalue.
+#' @param simplify Must be `TRUE`.
+#' `simplify = FALSE` is defunct as of embr 1.1.0.
 #' @param directional_information A flag specifying whether the svalue column
 #' for a Bayesian analysis should be calculated using
 #' [extras::directional_information()] instead of [extras::svalue()].
@@ -93,7 +94,9 @@ coef.mb_null_analysis <- function(
 #' set the argument explicitly to avoid the deprecation warning.
 #' Ignored for frequentist analyses where the svalue is always `-log2(pvalue)`.
 #' @param ... Not used.
-#' @return A tidy tibble of the coefficient terms.
+#' @return A tidy tibble of the coefficient terms with the columns indicating
+#' the `term`, `estimate`, `lower` and `upper` confidence or credible intervals
+#' and `svalue`.
 #' @export
 coef.mb_analysis <- function(
   object,
@@ -101,7 +104,7 @@ coef.mb_analysis <- function(
   include_constant = TRUE,
   conf_level = getOption("mb.conf_level", 0.95),
   estimate = getOption("mb.estimate", median),
-  simplify = FALSE,
+  simplify = TRUE,
   directional_information = FALSE,
   ...
 ) {
@@ -113,7 +116,11 @@ coef.mb_analysis <- function(
   chk_flag(simplify)
   chk_flag(directional_information)
 
-  if (simplify && missing(directional_information) && is_bayesian(object)) {
+  if (!simplify) {
+    lifecycle::deprecate_stop("1.1.0", "coef(simplify = 'must be TRUE')")
+  }
+
+  if (missing(directional_information) && is_bayesian(object)) {
     warn_default_directional_information()
   }
 
@@ -128,17 +135,15 @@ coef.mb_analysis <- function(
 
     coef <- get_frequentist_coef(coef)
 
-    if (simplify) {
-      coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
-      coef <- select(
-        coef,
-        "term",
-        "estimate",
-        "lower",
-        "upper",
-        "svalue"
-      )
-    }
+    coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
+    coef <- select(
+      coef,
+      "term",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
 
     class(coef) <- c("mb_analysis_coef", class(coef))
     return(coef)
@@ -172,17 +177,15 @@ coef.mb_analysis <- function(
     if (!include_constant) {
       coef <- dplyr::filter(coef, .data$lower != .data$upper)
     }
-    if (simplify) {
-      coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
-      coef <- select(
-        coef,
-        "term",
-        "estimate",
-        "lower",
-        "upper",
-        "svalue"
-      )
-    }
+    coef <- mutate(coef, svalue = -log(.data$pvalue, base = 2))
+    coef <- select(
+      coef,
+      "term",
+      "estimate",
+      "lower",
+      "upper",
+      "svalue"
+    )
   }
 
   class(coef) <- c("mb_analysis_coef", class(coef))

--- a/man/coef.mb_analysis.Rd
+++ b/man/coef.mb_analysis.Rd
@@ -10,7 +10,7 @@
   include_constant = TRUE,
   conf_level = getOption("mb.conf_level", 0.95),
   estimate = getOption("mb.estimate", median),
-  simplify = FALSE,
+  simplify = TRUE,
   directional_information = FALSE,
   ...
 )
@@ -26,7 +26,8 @@
 
 \item{estimate}{The function to use to calculating the estimate for Bayesian models.}
 
-\item{simplify}{A flag specifying whether to drop sd and zscore columns and return svalue instead of pvalue.}
+\item{simplify}{Must be \code{TRUE}.
+\code{simplify = FALSE} is defunct as of embr 1.1.0.}
 
 \item{directional_information}{A flag specifying whether the svalue column
 for a Bayesian analysis should be calculated using
@@ -38,11 +39,10 @@ Ignored for frequentist analyses where the svalue is always \code{-log2(pvalue)}
 \item{...}{Not used.}
 }
 \value{
-A tidy tibble of the coefficient terms.
+A tidy tibble of the coefficient terms with the columns indicating
+the \code{term}, \code{estimate}, \code{lower} and \code{upper} confidence or credible intervals
+and \code{svalue}.
 }
 \description{
 Coefficients for a JAGS analysis.
-}
-\details{
-The \code{zscore} is mean / sd.
 }

--- a/tests/testthat/test-coef.R
+++ b/tests/testthat/test-coef.R
@@ -35,6 +35,57 @@ test_that("coef directional_information for Bayesian analysis", {
   )
 })
 
+test_that("coef simplifies by default", {
+  analysis <- readRDS(
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
+  )
+
+  coef <- coef(analysis, directional_information = FALSE)
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
+})
+
+test_that("coef errors if simplify = FALSE", {
+  analysis <- readRDS(
+    file = system.file(
+      package = "embr",
+      "test-objects/analysis_jags_newexpr.RDS"
+    )
+  )
+
+  expect_error(
+    coef(analysis, simplify = FALSE),
+    "must be TRUE",
+    class = "defunctError"
+  )
+
+  null_analysis <- list(data = datasets::mtcars)
+  class(null_analysis) <- c("mb_null_analysis", "mb_analysis")
+
+  expect_error(
+    coef(null_analysis, simplify = FALSE),
+    "must be TRUE",
+    class = "defunctError"
+  )
+})
+
+test_that("coef simplifies null analysis by default", {
+  analysis <- list(data = datasets::mtcars)
+  class(analysis) <- c("mb_null_analysis", "mb_analysis")
+
+  coef <- coef(analysis)
+  expect_identical(
+    colnames(coef),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
+  expect_identical(nrow(coef), 0L)
+})
+
 test_that("coef soft-deprecates unset directional_information for Bayesian analysis", {
   analysis <- readRDS(
     file = system.file(

--- a/tests/testthat/test-mb-null-analysis.R
+++ b/tests/testthat/test-mb-null-analysis.R
@@ -6,7 +6,7 @@ test_that("mb_null_analysis", {
   expect_s3_class(coef, "tbl")
   expect_identical(
     colnames(coef),
-    c("term", "estimate", "sd", "zscore", "lower", "upper", "pvalue")
+    c("term", "estimate", "lower", "upper", "svalue")
   )
   expect_identical(nrow(coef), 0L)
 


### PR DESCRIPTION
Since poissonconsulting/mcmcr#74 made `coef(simplify = FALSE)` defunct, the previous default (`simplify = FALSE`) of `coef.mb_analysis()` and `coef.mb_null_analysis()` errored for every Bayesian analysis, which is breaking vignette building and pkgdown in downstream packages (e.g. jmbr).

This PR mirrors the mcmcr change:

- `simplify` now defaults to `TRUE` in `coef.mb_analysis()` and `coef.mb_null_analysis()`.
- `simplify = FALSE` is defunct via `lifecycle::deprecate_stop()` (as of embr 1.1.0), including for frequentist analyses.
- Documentation updated accordingly.

The soft deprecation warning when `directional_information` is not set explicitly for Bayesian analyses is unchanged, but now fires on default `coef(analysis)` calls since these are simplified.

Note the legacy ML paths that rely on unsimplified columns (`next_drop()` in `R/drops.R` and the model-averaging code in `coef.mb_analyses()` / `predict.mb_analyses()`) are untouched.

Pre-existing local test failures in `test-add-sensitivity.R` and `test-log-lik-draws.R` (`data$species must only have missing values`) occur on main too and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)